### PR TITLE
Prototype Crossplane resources to create a working ALB datapath

### DIFF
--- a/test-data/aws-alb/aws-alb.yaml
+++ b/test-data/aws-alb/aws-alb.yaml
@@ -1,0 +1,119 @@
+# This SG needs to be manually added as an 'allowed source' in the cluster SG
+apiVersion: ec2.aws.crossplane.io/v1beta1
+kind: SecurityGroup
+metadata:
+  name: aws-alb-test-shared
+spec:
+  providerConfigRef:
+    name: admin
+  forProvider:
+    description: "Common SG for ALBs"
+    groupName: aws-alb-test-shared
+    region: eu-central-1
+    vpcId: $VPC_ID
+    egress:
+    - ipRanges:
+      - cidrIp: 0.0.0.0/0
+      ipProtocol: tcp
+      fromPort: 80
+      toPort: 8080
+    ingress:
+    - ipRanges:
+      - cidrIp: 0.0.0.0/0
+      ipProtocol: tcp
+      fromPort: 80
+      toPort: 8080
+---
+apiVersion: elbv2.aws.crossplane.io/v1alpha1
+kind: LoadBalancer
+metadata:
+  name: aws-alb-test
+spec:
+  providerConfigRef:
+    name: admin
+  forProvider:
+    name: aws-alb-test
+    region: eu-central-1
+    securityGroups:
+    - $SG_ID
+    subnetMappings:
+    - subnetID: $SUBNET1
+    - subnetID: $SUBNET2
+    - subnetID: $SUBNET3
+---
+apiVersion: elbv2.aws.crossplane.io/v1alpha1
+kind: TargetGroup
+metadata:
+  name: aws-alb-test
+spec:
+  providerConfigRef:
+    name: admin
+  forProvider:
+    name: aws-alb-test
+    region: eu-central-1
+    vpcID: $VPC_ID
+    port: 8080
+    protocol: HTTP
+    targetType: ip
+---
+apiVersion: elbv2.aws.crossplane.io/v1alpha1
+kind: Listener
+metadata:
+  name: aws-alb-test
+spec:
+  providerConfigRef:
+    name: admin
+  forProvider:
+    region: eu-central-1
+    port: 8080
+    protocol: HTTP
+    loadBalancerArn: $ALB_ARN
+    defaultActions:
+    - actionType: forward
+      targetGroupArn: $TG_ARN
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: aws-alb-test
+  name: aws-alb-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aws-alb-test
+  template:
+    metadata:
+      labels:
+        app: aws-alb-test
+    spec:
+      containers:
+      - image: praqma/network-multitool
+        name: network-multitool
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: aws-alb-test
+  name: aws-alb-test
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: aws-alb-test
+  type: ClusterIP
+---
+apiVersion: elbv2.k8s.aws/v1beta1
+kind: TargetGroupBinding
+metadata:
+  name: aws-alb-test
+spec:
+  targetGroupARN: $TG_ARN
+  targetType: ip
+  serviceRef:
+    name: aws-alb-test
+    port: 8080

--- a/test-data/aws-alb/curl.sh
+++ b/test-data/aws-alb/curl.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+export ALB_DNS=$(kubectl get loadbalancer.elbv2.aws.crossplane.io/aws-alb-test -o jsonpath='{.status.atProvider.dnsName}')
+
+curl $ALB_DNS:8080

--- a/test-data/aws-alb/render.sh
+++ b/test-data/aws-alb/render.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+export VPC_ID=vpc-031e552470914799f
+export SUBNET1=subnet-01314e279c1540a54
+export SUBNET2=subnet-0763327f6870ebc5c
+export SUBNET3=subnet-0c22e47fd072c6093
+
+export SG_ID=$(kubectl get securitygroup.ec2.aws.crossplane.io/aws-alb-test-shared -o jsonpath='{.status.atProvider.securityGroupID}')
+export ALB_ARN=$(kubectl get loadbalancer.elbv2.aws.crossplane.io/aws-alb-test -o jsonpath='{.status.atProvider.loadBalancerARN}')
+export TG_ARN=$(kubectl get targetgroup.elbv2.aws.crossplane.io/aws-alb-test -o jsonpath='{.metadata.annotations.crossplane\.io/external-name}')
+
+cat aws-alb.yaml | envsubst > render.yaml


### PR DESCRIPTION
This PR contain an example Crossplane/AWS ALB datapath, i.e. which will be an input to the GatewayClass templates. We may never need to merge this PR - we could potentially just keep as a working ALB implementation, which we merge through another PR that updates the ALB template for the controller.

The `render.sh` script implements patching of variables between resources.