### PR TITLE
Export controller name for use in e.g. e2e test

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -8,10 +8,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
-)
 
-const (
-	SelfControllerName gatewayapi.GatewayController = "github.com/tv2/cloud-gateway-controller"
+	selfapi "github.com/tv2/cloud-gateway-controller/pkg/api"
 )
 
 type Controller interface {
@@ -19,7 +17,7 @@ type Controller interface {
 }
 
 func isOurGatewayClass(gwc *gatewayapi.GatewayClass) bool {
-	return gwc.Spec.ControllerName == SelfControllerName
+	return gwc.Spec.ControllerName == selfapi.SelfControllerName
 }
 
 func lookupGatewayClass(ctx context.Context, r Controller, name gatewayapi.ObjectName) (*gatewayapi.GatewayClass, error) {

--- a/controllers/httproute_controller.go
+++ b/controllers/httproute_controller.go
@@ -27,6 +27,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	selfapi "github.com/tv2/cloud-gateway-controller/pkg/api"
 )
 
 type HTTPRouteReconciler struct {
@@ -52,7 +54,7 @@ func lookupParent(ctx context.Context, r Controller, rt *gatewayapi.HTTPRoute, p
 func findParentRouteStatus(rtStatus *gatewayapi.RouteStatus, parent gatewayapi.ParentReference) *gatewayapi.RouteParentStatus {
 	for i := range rtStatus.Parents {
 		pStat := &rtStatus.Parents[i]
-		if pStat.ParentRef == parent && pStat.ControllerName == SelfControllerName {
+		if pStat.ParentRef == parent && pStat.ControllerName == selfapi.SelfControllerName {
 			return pStat
 		}
 	}
@@ -68,7 +70,7 @@ func setRouteStatusCondition(rtStatus *gatewayapi.RouteStatus, parent gatewayapi
 	if existingParentRouteStat == nil {
 		newStatus := gatewayapi.RouteParentStatus{
 			ParentRef:      parent,
-			ControllerName: SelfControllerName,
+			ControllerName: selfapi.SelfControllerName,
 			Conditions:     []metav1.Condition{*newCondition},
 		}
 		rtStatus.Parents = append(rtStatus.Parents, newStatus)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,0 +1,10 @@
+// Package api provide an exported API for the controller.
+package api
+
+import (
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+const (
+	SelfControllerName gatewayapi.GatewayController = "github.com/tv2/cloud-gateway-controller"
+)

--- a/test/e2e/controller_self_test.go
+++ b/test/e2e/controller_self_test.go
@@ -37,6 +37,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	cgwctlapi "github.com/tv2/cloud-gateway-controller/pkg/api"
 )
 
 const gatewayclassManifest string = `
@@ -217,7 +219,7 @@ var _ = Describe("Gateway addresses", func() {
 					len(rtRead.Status.RouteStatus.Parents[0].Conditions) != 1 ||
 					string(rtRead.Status.RouteStatus.Parents[0].ParentRef.Name) != gw.ObjectMeta.Name ||
 					string(*rtRead.Status.RouteStatus.Parents[0].ParentRef.Namespace) != gw.ObjectMeta.Namespace ||
-					// TODO: rtRead.Status.RouteStatus.Parents[0].ControllerName != "xxx"
+					rtRead.Status.RouteStatus.Parents[0].ControllerName != cgwctlapi.SelfControllerName ||
 					rtRead.Status.RouteStatus.Parents[0].Conditions[0].Type != string(gatewayapi.RouteConditionAccepted) ||
 					rtRead.Status.RouteStatus.Parents[0].Conditions[0].Status != "True" {
 					return false


### PR DESCRIPTION
This PR exports the controller name through a new 'api' package such that it can be used outside the controller, e.g. in the e2e tests. Eventually more 'api' related definitions may be added to this package.