### PR TITLE
Release working manifests

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -125,6 +125,10 @@ jobs:
           echo -n "HEAD_SHA=" >>${GITHUB_ENV}
           git rev-parse --short $GITHUB_SHA >>${GITHUB_ENV}
 
+      - name: Build release manifests
+        run: |
+          make manifest-build
+
       - name: Make release
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,7 +31,7 @@ release:
     ## Container Images
     - `ghcr.io/{{ .Env.REPOSITORY_OWNER }}/{{ .ProjectName }}:{{ .Version }}`
   extra_files:
-    - glob: config/manager/*
+    - glob: config/release/*
 
 dockers:
   - goarch: amd64

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,13 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
+.PHONY: manifest-build
+manifest-build:
+	mkdir config/release
+	# Currently we have no CRDs
+	#$(KUSTOMIZE) build config/crd -o config/release/crds.yaml
+	$(KUSTOMIZE) build config/default -o config/release/install.yaml
+
 # If you wish built the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,11 +1,4 @@
-# Adds namespace to all resources.
 namespace: cloud-gateway-controller-system
-
-# Value of this field is prepended to the
-# names of all resources, e.g. a deployment named
-# "wordpress" becomes "alices-wordpress".
-# Note that it should also match with the prefix (text before '-') of the namespace
-# field above.
 namePrefix: cloud-gateway-controller-
 
 # Labels to add to all resources and selectors.
@@ -15,7 +8,7 @@ namePrefix: cloud-gateway-controller-
 #    someName: someValue
 
 resources:
-- ../crd
+#- ../crd
 - ../rbac
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
@@ -26,11 +19,11 @@ resources:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+#patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+#- manager_auth_proxy_patch.yaml
 
 
 


### PR DESCRIPTION
This PR adds a make target that `kustomize build` manifests from the `default` kustomize overlay and include those in releases. The previously released manifests was missing the RBAC resources.

The `default` kustomize overlay have also been changed to not include CRDs. This allow us to release CRDs and the core-controller as separate manifest files. The auth-proxy feature in the `default` overlay have also been disabled. This is used to apply RBAC to the controllers metrics endpoint. With auth-proxy disabled, metrics are generally available in the cluster. Currently the controller have no metrics.