### PR TITLE
Simplify conversion from unstructured/typed-object to map

### DIFF
--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -110,7 +110,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	union, isect := combineHostnames(&gw, gwRoutes)
 
 	// Prepare Gateway resource for use in templates by converting to map[string]any
-	gatewayMap, err := objectToMap(&gw, r.Scheme())
+	gatewayMap, err := objectToMap(&gw)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("cannot convert gateway to map: %w", err)
 	}
@@ -145,13 +145,12 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	for attempt := 0; attempt < len(templates); attempt++ {
 		logger.Info("start reconcile loop", "attempt", attempt)
 		isFinalAttempt := attempt == len(templates)-1
-		templateValues.Resources, err = buildResourceValues(r, templates)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("unable to build values from current resources: %w", err)
-		}
+
+		templateValues.Resources = buildResourceValues(templates)
 
 		renderedNum, existsNum = renderTemplates(ctx, r, &gw, templates, &templateValues, isFinalAttempt)
 		logger.Info("Rendered", "rendered", renderedNum, "exists", existsNum)
+
 		if renderedNum == lastRenderedNum {
 			logger.Info("breaking render/apply loop", "renderedNum", renderedNum, "totalNum", len(templates))
 			break

--- a/controllers/httproute_controller.go
+++ b/controllers/httproute_controller.go
@@ -144,7 +144,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	logger.Info("HTTPRoute")
 
 	// Prepare HTTPRoute resource for use in templates by converting to map[string]any
-	rtMap, err := objectToMap(&rt, r.Scheme())
+	rtMap, err := objectToMap(&rt)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("cannot convert httproute to map: %w", err)
 	}
@@ -200,7 +200,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		templateValues.Values = values
 
 		// Prepare Gateway resource for use in templates by converting to map[string]any
-		gatewayMap, err := objectToMap(gw, r.Scheme())
+		gatewayMap, err := objectToMap(gw)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("cannot convert gateway to map: %w", err)
 		}
@@ -221,13 +221,12 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		for attempt := 0; attempt < len(templates); attempt++ {
 			logger.Info("start reconcile loop", "attempt", attempt)
 			isFinalAttempt := attempt == len(templates)-1
-			templateValues.Resources, err = buildResourceValues(r, templates)
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("unable to build values from current resources: %w", err)
-			}
+
+			templateValues.Resources = buildResourceValues(templates)
 
 			renderedNum, existsNum = renderTemplates(ctx, r, &rt, templates, &templateValues, isFinalAttempt)
 			logger.Info("Rendered", "rendered", renderedNum, "exists", existsNum)
+
 			if renderedNum == lastRenderedNum {
 				logger.Info("breaking render/apply loop", "renderedNum", renderedNum, "totalNum", len(templates))
 				break


### PR DESCRIPTION
This PR refactors/simplifies conversion functions from unstructured and typed-object into `map[string]any` by using upstream functionality.