### PR TITLE
Add dependabot ignores on client-go and api deps to keep some alignment with current Kubernetes versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,18 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    ignore:
+      # The version of client-go and api should approximately match target Kubernetes version, i.e. only update semver-patch version
+      # Minor version updates then becomes a manual procedure. Security updates are not ignored by this
+      - dependency-name: "k8s-io/client-go"
+        versions: ["version-update:semver-minor"]
+      - dependency-name: "k8s-io/api"
+        versions: ["version-update:semver-minor"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Client-go version should ideally match the target Kubernetes cluster version, however, older client-go's will typically work with new clusters. Hence a too-fast update of client-go is not ideal. This PR limits dependabot to only update patch versions and thus keep client-go and api deps at 0.26, which will be fine for some time. Patch-version and security updates are still applied.