### PR TITLE
Refactor chart release action

### DIFF
--- a/.github/workflows/chart-publish.yaml
+++ b/.github/workflows/chart-publish.yaml
@@ -1,16 +1,21 @@
-name: Release Charts
+name: Chart Release
 
 on:
   push:
     branches:
       - main
     paths:
-      - 'charts/gateway-controller/**'
+      - 'charts/bifrost-gateway-controller/Chart.yaml'
+
+env:
+  CHART: bifrost-gateway-controller
 
 jobs:
-  release:
+  release-helm:
     permissions:
-      contents: write
+      contents: read
+      packages: write
+      id-token: none
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -18,15 +23,66 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
       - name: Install Helm
         uses: azure/setup-helm@v3
+        with:
+          version: v3.11.3
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: login to ghcr.io using helm
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io/${{ github.repository }}-helm --username ${{ github.repository_owner }} --password-stdin
+
+      - name: save helm chart to local registry
+        run: |
+          helm package charts/$CHART
+
+      - name: publish chart to ghcr.io
+        id: chart-push
+        run: |
+          VERSION=$(cat charts/$CHART/Chart.yaml | awk -F "[, ]+" '/version/{print $NF}')
+          helm push "$CHART-helm-$VERSION.tgz" oci://ghcr.io/${{github.repository_owner}} 2>&1 | tee helm-push-out.txt
+          echo "chartVersion=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Chart meta
+        id: meta
+        run: |
+          DIGEST=$(cat helm-push-out.txt | awk -F "[, ]+" '/Digest/{print $NF}')
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+          CHART=$(echo ghcr.io/${{ github.repository }}-helm | tr '[:upper:]' '[:lower:]')
+          echo "chart=$CHART@$DIGEST" >> $GITHUB_OUTPUT
+
+    outputs:
+      chartVersion: ${{ steps.chart-push.outputs.chartVersion }}
+      digest: ${{ steps.meta.outputs.digest }}
+      chart: ${{ steps.meta.outputs.chart }}
+
+  sign-helm:
+    needs: release-helm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: none
+      packages: write
+      id-token: write
+
+    steps:
+    - name: Log in to the Container registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - uses: sigstore/cosign-installer@c3667d99424e7e6047999fb6246c0da843953c65 # tag=v3.0.1
+
+    - name: Sign chart
+      run: cosign sign --yes -a "chartVersion=${{ needs.release-helm.outputs.chartVersion }}" ${{ needs.release-helm.outputs.chart }}
+
+  verify-helm:
+    needs: [ release-helm, sign-helm ]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: sigstore/cosign-installer@c3667d99424e7e6047999fb6246c0da843953c65 # tag=v3.0.1
+
+    - name: Verify signature
+      run: cosign verify --certificate-identity-regexp 'https://github.com/${{ github.repository }}/.github/workflows/chart-publish.yaml@refs/.*' --certificate-oidc-issuer https://token.actions.githubusercontent.com ${{ needs.release-helm.outputs.chart }}

--- a/charts/bifrost-gateway-controller/CHANGELOG.md
+++ b/charts/bifrost-gateway-controller/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## [UNRELEASED]
 
-- Example text, replace with PR info according to example below. Do not bump chart version in Chart.yaml.
+- Example text, add your PR info according to example below below this line. Do not bump chart version in Chart.yaml.
 
+## [0.1.6]
+
+- Refactor chart release action. ([#143](https://github.com/tv2-oss/bifrost-gateway-controller/pull/143)) [@michaelvl](https://github.com/michaelvl)
 
 ## [0.1.5]
 

--- a/charts/bifrost-gateway-controller/CHANGELOG.md
+++ b/charts/bifrost-gateway-controller/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [UNRELEASED]
 
-- Example text, replace with PR info according to example below.
+- Example text, replace with PR info according to example below. Do not bump chart version in Chart.yaml.
 
 
 ## [0.1.5]

--- a/charts/bifrost-gateway-controller/Chart.yaml
+++ b/charts/bifrost-gateway-controller/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: bifrost-gateway-controller
+name: bifrost-gateway-controller-helm
 description: Gateway API driven management of network infrastructure across Kubernetes and cloud infrastructure
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "0.0.13"

--- a/charts/bifrost-gateway-controller/README.md
+++ b/charts/bifrost-gateway-controller/README.md
@@ -1,6 +1,6 @@
-# bifrost-gateway-controller
+# bifrost-gateway-controller-helm
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.13](https://img.shields.io/badge/AppVersion-0.0.13-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.13](https://img.shields.io/badge/AppVersion-0.0.13-informational?style=flat-square)
 
 Gateway API driven management of network infrastructure across Kubernetes and cloud infrastructure
 


### PR DESCRIPTION
**Description**

This PR refactors the chart release process. This removes the conflicting tagging triggered by `chart`-releaser-action`.

Charts are now packaged with `helm package` and push to the `ghcr.io` OCI container registry instead of a branch in the repo. This also means, that actions no longer need to have write access to the repo. Charts are also signed with `cosign`.

This PR does not update user docs - a follow up PR will do that using a chart published to the container registry.

