### PR TITLE
Depenabot should ignore all minor updates of k8s.io dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,9 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      # The version of client-go and api should approximately match target Kubernetes version, i.e. only update semver-patch version
+      # The version of client-go and other Kubernetes APIs should approximately match target Kubernetes version, i.e. only update semver-patch version
       # Minor version updates then becomes a manual procedure. Security updates are not ignored by this
-      - dependency-name: "k8s.io/client-go"
-        versions: ["version-update:semver-minor"]
-      - dependency-name: "k8s.io/api"
+      - dependency-name: "k8s.io/*"
         versions: ["version-update:semver-minor"]
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
**Description**

Kubernetes dependency versions should ideally match the target Kubernetes cluster version. Hence a too-fast update of client-go etc. is not ideal. This PR limits dependabot to only update patch versions and thus keep all `k8s.io` dependencies at 0.26, which will be fine for some time. Patch-version and security updates are still applied.