### PR TITLE
Update gateway-api to 0.6.2

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -43,14 +43,14 @@ wait-ready-external-dns-test:
 	until kubectl wait pods -l app.kubernetes.io/instance=external-dns --for condition=Ready --timeout=120s     ; do echo "."; sleep 1; done
 
 #################
-GATEWAY_API_VERSION ?= v0.6.0
+GATEWAY_API_VERSION ?= v0.6.2
 
 .PHONY: gateway-api-upstream-get
 gateway-api-upstream-get:
 	mkdir -p upstream-gateway-api/crds upstream-gateway-api/webhook
 	kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=$(GATEWAY_API_VERSION)" > upstream-gateway-api/crds/crds.yaml
 	#kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=$(GATEWAY_API_VERSION)" > upstream-gateway-api-crds/crds.yaml
-	(cd upstream-gateway-api/webhook && for manifestfile in 0-namespace.yaml admission_webhook.yaml certificate_config.yaml; do curl -sL -O https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/main/config/webhook/$$manifestfile; done)
+	(cd upstream-gateway-api/webhook && for manifestfile in 0-namespace.yaml admission_webhook.yaml certificate_config.yaml; do curl -sL -O https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/$(GATEWAY_API_VERSION)/config/webhook/$$manifestfile; done)
 
 .PHONY: deploy-gateway-api
 deploy-gateway-api:

--- a/upstream-gateway-api/crds/crds.yaml
+++ b/upstream-gateway-api/crds/crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.0
+    gateway.networking.k8s.io/bundle-version: v0.6.2
     gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: gatewayclasses.gateway.networking.k8s.io
@@ -439,7 +439,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.0
+    gateway.networking.k8s.io/bundle-version: v0.6.2
     gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: gateways.gateway.networking.k8s.io
@@ -1873,7 +1873,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/1538
-    gateway.networking.k8s.io/bundle-version: v0.6.0
+    gateway.networking.k8s.io/bundle-version: v0.6.2
     gateway.networking.k8s.io/channel: standard
   creationTimestamp: null
   name: httproutes.gateway.networking.k8s.io

--- a/upstream-gateway-api/webhook/admission_webhook.yaml
+++ b/upstream-gateway-api/webhook/admission_webhook.yaml
@@ -56,7 +56,7 @@ spec:
     spec:
       containers:
         - name: webhook
-          image: gcr.io/k8s-staging-gateway-api/admission-server:v0.6.0
+          image: gcr.io/k8s-staging-gateway-api/admission-server:v0.6.2
           imagePullPolicy: Always
           args:
             - -logtostderr

--- a/upstream-gateway-api/webhook/certificate_config.yaml
+++ b/upstream-gateway-api/webhook/certificate_config.yaml
@@ -28,7 +28,6 @@ metadata:
   annotations:
   labels:
     name: gateway-api-webhook
-  namespace: gateway-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -89,7 +88,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -123,7 +122,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1
+          image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1
           imagePullPolicy: IfNotPresent
           args:
             - patch


### PR DESCRIPTION
**Description**

- Update `Makefile.local` to use specific version of gateway-api webhook (used `main` version)
- Update local gateway-api CRD and webhook artifacts to 0.6.2 (code already used 0.6.2)
