### PR TITLE
test: update getting started guide and enable external dns filter

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -104,7 +104,7 @@ deploy-multitool:
 #################
 .PHONY: deploy-external-dns
 deploy-external-dns:
-	helm upgrade -i --repo https://kubernetes-sigs.github.io/external-dns external-dns external-dns --version 1.12.0 --values test-data/external-dns-values.yaml
+	helm upgrade -i --repo https://kubernetes-sigs.github.io/external-dns external-dns external-dns --version 1.12.2 --values test-data/external-dns-values.yaml
 
 #################
 # https://kind.sigs.k8s.io/docs/user/loadbalancer/
@@ -208,7 +208,7 @@ undeploy-controller:
 	helm uninstall -n bifrost-gateway-controller-system bifrost-gateway-controller-helm
 
 #################
-BIFROST_BLUEPRINTS_VERSION ?= 0.0.18
+BIFROST_BLUEPRINTS_VERSION ?= 0.0.19
 
 .PHONY: deploy-controller-blueprint
 setup-getting-started-controller-blueprint:

--- a/blueprints/contour-istio/gatewayclassblueprint-contour-istio-cert.yaml
+++ b/blueprints/contour-istio/gatewayclassblueprint-contour-istio-cert.yaml
@@ -25,7 +25,18 @@ spec:
         spec:
           gatewayClassName: istio
           listeners:
-            {{- toYaml .Gateway.spec.listeners | nindent 6 }}
+          {{- range .Gateway.spec.listeners }}
+          - name: {{ .name }}
+            port: 80
+            protocol: HTTP
+            {{ if get . "hostname" }}
+            hostname: {{ .hostname | quote }}
+            {{ end -}}
+            {{ if get . "allowedRoutes" }}
+            allowedRoutes:
+              {{ toYaml .allowedRoutes | nindent 6 }}
+            {{ end -}}
+          {{- end }}
       loadBalancer: |
         apiVersion: networking.k8s.io/v1
         kind: Ingress

--- a/blueprints/contour-istio/gatewayclassblueprint-contour-istio.yaml
+++ b/blueprints/contour-istio/gatewayclassblueprint-contour-istio.yaml
@@ -18,7 +18,18 @@ spec:
         spec:
           gatewayClassName: istio
           listeners:
-            {{- toYaml .Gateway.spec.listeners | nindent 6 }}
+          {{- range .Gateway.spec.listeners }}
+          - name: {{ .name }}
+            port: 80
+            protocol: HTTP
+            {{ if get . "hostname" }}
+            hostname: {{ .hostname | quote }}
+            {{ end -}}
+            {{ if get . "allowedRoutes" }}
+            allowedRoutes:
+              {{ toYaml .allowedRoutes | nindent 6 }}
+            {{ end -}}
+          {{- end }}
       loadBalancer: |
         apiVersion: networking.k8s.io/v1
         kind: Ingress

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -182,6 +182,20 @@ curl --cacert foo-example-com.crt --resolve foo.example.com:443:127.0.0.1 https:
 curl --cacert foo-example-com.crt --resolve foo.example.com:443:127.0.0.1 https://foo.example.com/store
 ```
 
+### Testing Integration with DNS
+
+The KIND cluster for the getting-started example includes a deployment
+of [external-dns](https://github.com/kubernetes-sigs/external-dns),
+configured to update a test-only CoreDNS instance. This CoreDNS
+instance can be quieried using the tooling container also deployed as
+part of the KIND cluster setup:
+
+```
+kubectl exec -it deploy/multitool -- dig @coredns-test-only-coredns example.com +short
+```
+
+The output should be the same IP address as reported from `kubectl get gateway -n foo-infra` in the `ADDRESS` column.
+
 ## Cleanup
 
 ```

--- a/hack/demo/foo-gateway.yaml
+++ b/hack/demo/foo-gateway.yaml
@@ -3,6 +3,8 @@ kind: Gateway
 metadata:
   name: foo-gateway
   namespace: foo-infra
+  labels:
+    external-dns/export: "true"
 spec:
   gatewayClassName: aws-alb-crossplane-public
   listeners:

--- a/test-data/coredns-test-values.yaml
+++ b/test-data/coredns-test-values.yaml
@@ -14,9 +14,7 @@ servers:
   - name: ready
   - name: reload
   - name: loadbalance
-  # Addition for local test
   - name: etcd
-    parameters: example-foo4567.com
     configBlock: |-
       stubzones
       path /skydns

--- a/test-data/external-dns-values.yaml
+++ b/test-data/external-dns-values.yaml
@@ -13,3 +13,4 @@ sources:
 logLevel: debug
 extraArgs:
 - --gateway-label-filter=external-dns/export==true
+- --domain-filter=example-foo4567.com

--- a/test-data/external-dns-values.yaml
+++ b/test-data/external-dns-values.yaml
@@ -1,3 +1,4 @@
+policy: sync
 env:
  - name: ETCD_URLS
    value: http://etcd-test-only-headless:2379
@@ -7,9 +8,8 @@ rbac:
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get","watch","list"]
-  - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gateways","httproutes","grpcroutes","tlsroutes","tcproutes","udproutes"] 
-    verbs: ["get","watch","list"]
 sources:
  - gateway-httproute
 logLevel: debug
+extraArgs:
+- --gateway-label-filter=external-dns/export==true

--- a/test-data/getting-started/foo-gateway.yaml
+++ b/test-data/getting-started/foo-gateway.yaml
@@ -3,6 +3,8 @@ kind: Gateway
 metadata:
   name: foo-gateway
   namespace: foo-infra
+  labels:
+    external-dns/export: "true"
 spec:
   gatewayClassName: $GATEWAY_CLASS_NAME
   listeners:

--- a/test/e2e/controller_self_test.go
+++ b/test/e2e/controller_self_test.go
@@ -128,6 +128,8 @@ kind: Gateway
 metadata:
   name: foo-gateway
   namespace: default
+  labels:
+    external-dns/export: "true"
 spec:
   gatewayClassName: cloud-gw
   listeners:


### PR DESCRIPTION
**Description**

This PR updates the external-dns and bifrost versions used in make targets.

The `contour-istio` blueprint child gateway template is aligned with `aws-crossplane-istio`. The reason for this construction of the gateway listener section is to avoid passing the `tls` section from parent gateway to child gateway since TLS is termianted at the parent.

This also contains test/documentation updates. The getting-started usecase is updated to illustrate integration with external-dns. External-dns is enabled through a label on `Gateway`s.

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
- [x] If changes apply to Helm chart, a note have been made in the 'UNRELEASED' section of the charts CHANGELOG.md
