### PR TITLE
Drop invalid HTTP headers on AWS ALBs

### DIFF
--- a/blueprints/aws-alb-crossplane/gatewayclassblueprint-aws-alb-crossplane.yaml
+++ b/blueprints/aws-alb-crossplane/gatewayclassblueprint-aws-alb-crossplane.yaml
@@ -72,9 +72,10 @@ spec:
           providerConfigRef:
             name: {{ .Values.providerConfigName }}
           forProvider:
+            dropInvalidHeaderFields: true
+            internal: {{ .Values.internal }}
             name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
             region: {{ .Values.region }}
-            internal: {{ .Values.internal }}
             securityGroupSelector:
               matchLabels:
                 tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}


### PR DESCRIPTION
**Description**

Configure AWS ALBs to drop invalid HTTP headers. AWS security hub reports this as a 'medium' severity.

Also reordered LB settings alphabetically.

