### PR TITLE
Add aws crossplane private gatewayclass

### DIFF
--- a/blueprints/aws-alb-crossplane/README.md
+++ b/blueprints/aws-alb-crossplane/README.md
@@ -24,7 +24,7 @@ the Istio ingress gateway.
 This definition is provided in the following files:
 
 - [`gatewayclassblueprint-aws-alb-crossplane.yaml`](gatewayclassblueprint-aws-alb-crossplane.yaml) blueprint for infrastructure implementation
-- [`gatewayclass-aws-alb-crossplane.yaml`](gatewayclass-aws-alb-crossplane.yaml) definitions of `GatewayClass`es referencing the above `GatewayClassBlueprint`. Two `GatewayClass`es are created, one that is intended for internet exposed gateways, and one for non internet exposed gateways.
+- [`gatewayclass-aws-alb-crossplane.yaml`](gatewayclass-aws-alb-crossplane.yaml) definitions of `GatewayClass`es referencing the above `GatewayClassBlueprint`. Three `GatewayClass`es are created, one that is intended for internet exposed gateways (`public`), one for internet exposed gateways but access limited by e.g. ACLs (`private`) and one for non internet exposed gateways (`internal`).
 - [`gatewayclassconfig-aws-alb-crossplane-dev-env.yaml`](../../test-data/gatewayclassconfig-aws-alb-crossplane-dev-env.yaml) example settings for the two `GatewayClass`es defined in `gatewayclass-aws-alb-crossplane.yaml`, i.e. with different subnet settings for the internet-exposed and non internet-exposed `GatewayClass'es.
 - [`gatewayclassblueprint-crossplane-aws-alb-values.yaml`](../../charts/bifrost-gateway-controller/ci/gatewayclassblueprint-crossplane-aws-alb-values.yaml)
 RBAC for bifrost-gateway-controller Helm deployment suited for the `aws-alb-crossplane` blueprint.

--- a/blueprints/aws-alb-crossplane/gatewayclass-aws-alb-crossplane.yaml
+++ b/blueprints/aws-alb-crossplane/gatewayclass-aws-alb-crossplane.yaml
@@ -1,3 +1,7 @@
+# The naming convention is:
+# public - for internet exposed gateways
+# private - for internet exposed gateways but access limited by e.g. ACLs
+# internal - for non internet exposed gateways
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
@@ -17,6 +21,19 @@ metadata:
 spec:
   controllerName: "github.com/tv2-oss/bifrost-gateway-controller"
   description: "Internal AWS ALB and Istio ingress gateway"
+  parametersRef:
+    group: gateway.tv2.dk
+    kind: GatewayClassBlueprint
+    name: aws-alb-crossplane
+---
+# This 'private' GatewayClass will need additional attached policies to limit access
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: GatewayClass
+metadata:
+  name: aws-alb-crossplane-private
+spec:
+  controllerName: "github.com/tv2-oss/bifrost-gateway-controller"
+  description: "Private AWS ALB and Istio ingress gateway"
   parametersRef:
     group: gateway.tv2.dk
     kind: GatewayClassBlueprint


### PR DESCRIPTION
**Description**

This PR adds another named `GatewayClass` using the AWS/Crossplane blueprint. The new 'private' `GatewayClass` is intended to be different from the 'public' class by having different atached policy defaults. This is however outside the scope of this PR.
