### PR TITLE
Support multiple resources per template, aka. loops and conditions

### DIFF
--- a/blueprints/aws-alb-crossplane/gatewayclassblueprint-aws-alb-crossplane.yaml
+++ b/blueprints/aws-alb-crossplane/gatewayclassblueprint-aws-alb-crossplane.yaml
@@ -33,7 +33,7 @@ spec:
       template: |
         addresses:
         - type: Hostname
-          value: {{ .Resources.LB.status.atProvider.dnsName }}
+          value: {{ (index .Resources.LB 0).status.atProvider.dnsName }}
     resourceTemplates:
       childGateway: |
         apiVersion: gateway.networking.k8s.io/v1beta1
@@ -153,7 +153,7 @@ spec:
             {{- toYaml .Values.tags | nindent 4 }}
           {{ end }}
         spec:
-          targetGroupARN: {{ .Resources.LBTargetGroup.status.atProvider.arn }}
+          targetGroupARN: {{ (index .Resources.LBTargetGroup 0).status.atProvider.arn }}
           targetType: ip
           serviceRef:
             name: {{ .Gateway.metadata.name }}-child

--- a/blueprints/contour-istio/gatewayclassblueprint-contour-istio-cert.yaml
+++ b/blueprints/contour-istio/gatewayclassblueprint-contour-istio-cert.yaml
@@ -9,7 +9,7 @@ spec:
     status:
       template: |
         addresses:
-        {{ range .Resources.loadBalancer.status.loadBalancer.ingress }}
+        {{ range (index .Resources.loadBalancer 0).status.loadBalancer.ingress }}
         - type: IPAddress
           value: {{ .ip }}
         {{ end }}

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -173,7 +173,7 @@ spec:
     name: default
 `
 
-var _ = Describe("Common functions", func() {
+var _ = Describe("Attached policies and value precedence", func() {
 
 	const (
 		timeout  = time.Second * 10

--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -186,13 +186,13 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if tmpl, errs := parseSingleTemplate("status", tmplStr); errs != nil {
 			logger.Info("unable to parse status template", "temporary error", errs)
 		} else {
-			if statusMap, errs := template2map(tmpl, &templateValues); errs != nil {
+			if statusMap, errs := template2maps(tmpl, &templateValues); errs != nil {
 				logger.Info("unable to render status template", "temporary error", errs, "template", tmplStr, "values", templateValues)
 			} else {
 				gw.Status.Addresses = []gatewayapi.GatewayAddress{}
-				_, found := statusMap["addresses"]
+				_, found := statusMap[0]["addresses"] // FIXME, more addresses?
 				if found {
-					addresses := statusMap["addresses"]
+					addresses := statusMap[0]["addresses"]
 					if errs := mapstructure.Decode(addresses, &gw.Status.Addresses); errs != nil {
 						// This is probably not a temporary error
 						logger.Error(errs, "unable to decode status data")

--- a/controllers/gateway_controller_test.go
+++ b/controllers/gateway_controller_test.go
@@ -81,6 +81,12 @@ kind: GatewayClassBlueprint
 metadata:
   name: default-gateway-class
 spec:
+  values:
+    default:
+      configmap2SuffixData:
+      - one
+      - two
+      - three
   gatewayTemplate:
     status:
       template: |
@@ -109,14 +115,25 @@ spec:
         data:
           valueToRead1: Hello
           valueToRead2: World
-      configMapTestIntermediate: |
+      configMapTestIntermediate1: |
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: intermediate-configmap
+          name: intermediate1-configmap
           namespace: {{ .Gateway.metadata.namespace }}
         data:
           valueIntermediate: {{ (index .Resources.configMapTestSource 0).data.valueToRead1 }}
+      configMapTestIntermediate2: |
+        {{ range .Values.configmap2SuffixData }}
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: intermediate2-configmap-{{ . }}
+          namespace: {{ $.Gateway.metadata.namespace }}
+        data:
+          valueIntermediate: {{ (index $.Resources.configMapTestSource 0).data.valueToRead1 }}-{{ . }}
+        ---
+        {{ end }}
       # Use references to multiple resources coupled with template pipeline and functions
       configMapTestDestination: |
         apiVersion: v1
@@ -125,7 +142,8 @@ spec:
           name: dst-configmap
           namespace: {{ .Gateway.metadata.namespace }}
         data:
-          valueRead: {{ printf "%s, %s" (index .Resources.configMapTestIntermediate 0).data.valueIntermediate (index .Resources.configMapTestSource 0).data.valueToRead2 | upper }}
+          valueRead: {{ printf "%s, %s" (index .Resources.configMapTestIntermediate1 0).data.valueIntermediate (index .Resources.configMapTestSource 0).data.valueToRead2 | upper }}
+          valueRead2: {{ printf "Testing, one two %s" (index .Resources.configMapTestIntermediate2 2).data.valueIntermediate | upper }}
   httpRouteTemplate:
     resourceTemplates:
       shadowHttproute: |
@@ -270,6 +288,7 @@ var _ = Describe("Gateway controller", func() {
 
 			By("Setting the content of the destination configmap")
 			Expect(cm.Data["valueRead"]).To(Equal("HELLO, WORLD"))
+			Expect(cm.Data["valueRead2"]).To(Equal("TESTING, ONE TWO HELLO-THREE"))
 		})
 	})
 })

--- a/controllers/gateway_controller_test.go
+++ b/controllers/gateway_controller_test.go
@@ -124,14 +124,14 @@ spec:
         data:
           valueIntermediate: {{ (index .Resources.configMapTestSource 0).data.valueToRead1 }}
       configMapTestIntermediate2: |
-        {{ range .Values.configmap2SuffixData }}
+        {{ range $idx,$suffix := .Values.configmap2SuffixData }}
         apiVersion: v1
         kind: ConfigMap
         metadata:
-          name: intermediate2-configmap-{{ . }}
+          name: intermediate2-configmap-{{ $idx }}
           namespace: {{ $.Gateway.metadata.namespace }}
         data:
-          valueIntermediate: {{ (index $.Resources.configMapTestSource 0).data.valueToRead1 }}-{{ . }}
+          valueIntermediate: {{ (index $.Resources.configMapTestSource 0).data.valueToRead1 }}-{{ $suffix }}
         ---
         {{ end }}
       # Use references to multiple resources coupled with template pipeline and functions

--- a/controllers/gateway_controller_test.go
+++ b/controllers/gateway_controller_test.go
@@ -85,7 +85,7 @@ spec:
     status:
       template: |
         addresses:
-          {{ toYaml .Resources.childGateway.status.addresses | nindent 2}}
+          {{ toYaml (index .Resources.childGateway 0).status.addresses | nindent 2}}
     resourceTemplates:
       childGateway: |
         apiVersion: gateway.networking.k8s.io/v1beta1
@@ -116,7 +116,7 @@ spec:
           name: intermediate-configmap
           namespace: {{ .Gateway.metadata.namespace }}
         data:
-          valueIntermediate: {{ .Resources.configMapTestSource.data.valueToRead1 }}
+          valueIntermediate: {{ (index .Resources.configMapTestSource 0).data.valueToRead1 }}
       # Use references to multiple resources coupled with template pipeline and functions
       configMapTestDestination: |
         apiVersion: v1
@@ -125,7 +125,7 @@ spec:
           name: dst-configmap
           namespace: {{ .Gateway.metadata.namespace }}
         data:
-          valueRead: {{ printf "%s, %s" .Resources.configMapTestIntermediate.data.valueIntermediate .Resources.configMapTestSource.data.valueToRead2 | upper }}
+          valueRead: {{ printf "%s, %s" (index .Resources.configMapTestIntermediate 0).data.valueIntermediate (index .Resources.configMapTestSource 0).data.valueToRead2 | upper }}
   httpRouteTemplate:
     resourceTemplates:
       shadowHttproute: |

--- a/controllers/statuscheck.go
+++ b/controllers/statuscheck.go
@@ -38,12 +38,12 @@ import (
 // Given a slice of template states, compute the overall
 // health/readiness status.  The general approach is to test for a
 // `Ready` status condition, which is implemented through kstatus.
-func statusIsReady(templates []*TemplateResource) (bool, error) {
+func statusIsReady(templates []*ResourceTemplateState) (bool, error) {
 	for _, tmplRes := range templates {
-		if tmplRes.Current == nil {
+		if tmplRes.Resource.Current == nil {
 			return false, nil
 		}
-		res, err := status.Compute(tmplRes.Current)
+		res, err := status.Compute(tmplRes.Resource.Current)
 		if err != nil {
 			return false, err
 		}
@@ -55,10 +55,10 @@ func statusIsReady(templates []*TemplateResource) (bool, error) {
 }
 
 // Build a list of template names which are not yet reconciled. Useful for status reporting
-func statusExistingTemplates(templates []*TemplateResource) []string {
+func statusExistingTemplates(templates []*ResourceTemplateState) []string {
 	var missing []string
 	for _, tmplRes := range templates {
-		if tmplRes.Current == nil {
+		if tmplRes.Resource.Current == nil {
 			missing = append(missing, tmplRes.TemplateName)
 		}
 	}

--- a/controllers/statuscheck.go
+++ b/controllers/statuscheck.go
@@ -42,7 +42,7 @@ import (
 // `Ready` status condition, which is implemented through kstatus.
 func statusIsReady(templates []*ResourceTemplateState) (bool, error) {
 	for _, tmpl := range templates {
-		for _, res := range tmpl.NewResource {
+		for _, res := range tmpl.NewResources {
 			if res.Current == nil {
 				return false, nil
 			}
@@ -62,7 +62,7 @@ func statusIsReady(templates []*ResourceTemplateState) (bool, error) {
 func statusExistingTemplates(templates []*ResourceTemplateState) []string {
 	var missing []string
 	for _, tmpl := range templates {
-		for resIdx, res := range tmpl.NewResource {
+		for resIdx, res := range tmpl.NewResources {
 			if res.Current == nil {
 				missing = append(missing, fmt.Sprintf("%s[%d]", tmpl.TemplateName, resIdx))
 			}

--- a/controllers/templating.go
+++ b/controllers/templating.go
@@ -73,15 +73,14 @@ type ResourceTemplateState struct {
 	// Compiled template
 	Template *template.Template
 
-	// Resource information, rendered and current
-	OldResource  ResourceComposite   // FIXME, refactoring - delete and replace with below
-	NewResources []ResourceComposite // FIXME, refactoring temp name
-
 	// Name of template (from template key in GatewayClassBlueprint, not Kubernetes resource name)
 	TemplateName string
 
 	// Raw template
 	StringTemplate string
+
+	// Resource information, rendered and current
+	NewResources []ResourceComposite // FIXME, refactoring temp name
 }
 
 // Parameters used when rendering templates

--- a/controllers/templating_test.go
+++ b/controllers/templating_test.go
@@ -22,8 +22,8 @@ t2: |
     name: {{ .Values.name2 }}
     {{ end }}
 t3: |
-    {{ range .Values.t3data }}
-    name: {{ $.Values.name3 }}-{{ . }}
+    {{ range $idx,$data := .Values.t3data }}
+    name: {{ $.Values.name3 }}-{{ $data }}-{{ $idx }}
     ---
     {{ end }}
 `
@@ -96,5 +96,8 @@ func TestTemplate2map(t *testing.T) {
 	}
 	if len(rawResources) != 3 {
 		t.Fatalf("Error rendering multi-resource, got len %v, expected 3", len(rawResources))
+	}
+	if rawResources[2]["name"] != "t3name-foo3-2" {
+		t.Fatalf("Rendered template error, got %v, expected 't3name-foo3-2'", rawResources[2]["name"])
 	}
 }

--- a/controllers/templating_test.go
+++ b/controllers/templating_test.go
@@ -58,8 +58,8 @@ func TestParseTemplate(t *testing.T) {
 	if tmpl == nil || err != nil {
 		t.Fatalf("Error parsing templates %v", err)
 	}
-	if len(tmpl) != 2 {
-		t.Fatalf("Template slice lenght mismatch, got %v, expected 2", len(tmpl))
+	if len(tmpl) != 3 {
+		t.Fatalf("Template slice lenght mismatch, got %v, expected 3", len(tmpl))
 	}
 	if tmpl[0].TemplateName != "t1" {
 		t.Fatalf("Template[0] name, got %v, expected t1", tmpl[0].TemplateName)
@@ -92,28 +92,5 @@ func TestTemplate2map(t *testing.T) {
 	}
 	if len(rawResources) != 3 {
 		t.Fatalf("Error rendering multi-resource, got len %v, expected 3", len(rawResources))
-	}
-}
-
-func TestTemplate2Unstructured(t *testing.T) {
-	tmpl, err := helperGetResourceState()
-	tmplValues := helperGetValues()
-	u, err := template2Unstructured(tmpl[0].Template, tmplValues)
-	if u == nil {
-		t.Fatalf("Cannot render template to map: %v", err)
-	}
-	u, err = template2Unstructured(tmpl[1].Template, tmplValues)
-	if err != nil {
-		t.Fatalf("Error rendering empty resource, got err %v", err)
-	}
-	if len(u) != 0 {
-		t.Fatalf("Error rendering empty resource, got %v, expected 0", len(u))
-	}
-	u, err = template2Unstructured(tmpl[2].Template, tmplValues)
-	if err != nil {
-		t.Fatalf("Error rendering multi-resource, got err %v", err)
-	}
-	if len(u) != 3 {
-		t.Fatalf("Error rendering multi-resource, got len %v, expected 3", len(u))
 	}
 }

--- a/controllers/templating_test.go
+++ b/controllers/templating_test.go
@@ -1,8 +1,9 @@
 package controllers
 
 import (
-	"k8s.io/apimachinery/pkg/util/yaml"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 func TestParseSingleTemplate(t *testing.T) {
@@ -59,7 +60,7 @@ func TestParseTemplate(t *testing.T) {
 		t.Fatalf("Error parsing templates %v", err)
 	}
 	if len(tmpl) != 3 {
-		t.Fatalf("Template slice lenght mismatch, got %v, expected 3", len(tmpl))
+		t.Fatalf("Template slice length mismatch, got %v, expected 3", len(tmpl))
 	}
 	if tmpl[0].TemplateName != "t1" {
 		t.Fatalf("Template[0] name, got %v, expected t1", tmpl[0].TemplateName)
@@ -68,9 +69,12 @@ func TestParseTemplate(t *testing.T) {
 
 func TestTemplate2map(t *testing.T) {
 	tmpl, err := helperGetResourceState()
+	if err != nil {
+		t.Fatalf("Cannot get resource state: %v", err)
+	}
 	tmplValues := helperGetValues()
 	rawResources, err := template2maps(tmpl[0].Template, tmplValues)
-	if rawResources == nil {
+	if rawResources == nil || err != nil {
 		t.Fatalf("Cannot render template to map: %v", err)
 	}
 	if len(rawResources) != 1 {

--- a/controllers/templating_test.go
+++ b/controllers/templating_test.go
@@ -1,0 +1,119 @@
+package controllers
+
+import (
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"testing"
+)
+
+func TestParseSingleTemplate(t *testing.T) {
+	template := "foo"
+	tmpl, err := parseSingleTemplate("foo", template)
+	if tmpl == nil || err != nil {
+		t.Fatalf("Error parsing template %v", err)
+	}
+}
+
+var textTemplate = `
+t1: |
+    name: {{ .Values.name1 }}
+t2: |
+    {{ if .Values.t2enable }}
+    name: {{ .Values.name2 }}
+    {{ end }}
+t3: |
+    {{ range .Values.t3data }}
+    name: {{ $.Values.name3 }}-{{ . }}
+    ---
+    {{ end }}
+`
+
+var textValues = `
+name1: t1name
+name2: t2name
+name3: t3name
+t2enable: false
+t3data:
+- foo1
+- foo2
+- foo3
+`
+
+func helperGetResourceState() ([]*ResourceTemplateState, error) {
+	templates := map[string]string{}
+	_ = yaml.Unmarshal([]byte(textTemplate), &templates)
+	return parseTemplates(templates)
+}
+
+func helperGetValues() *TemplateValues {
+	values := map[string]any{}
+	_ = yaml.Unmarshal([]byte(textValues), &values)
+	templateValues := TemplateValues{
+		Values: values,
+	}
+	return &templateValues
+}
+
+func TestParseTemplate(t *testing.T) {
+	tmpl, err := helperGetResourceState()
+	if tmpl == nil || err != nil {
+		t.Fatalf("Error parsing templates %v", err)
+	}
+	if len(tmpl) != 2 {
+		t.Fatalf("Template slice lenght mismatch, got %v, expected 2", len(tmpl))
+	}
+	if tmpl[0].TemplateName != "t1" {
+		t.Fatalf("Template[0] name, got %v, expected t1", tmpl[0].TemplateName)
+	}
+}
+
+func TestTemplate2map(t *testing.T) {
+	tmpl, err := helperGetResourceState()
+	tmplValues := helperGetValues()
+	rawResources, err := template2maps(tmpl[0].Template, tmplValues)
+	if rawResources == nil {
+		t.Fatalf("Cannot render template to map: %v", err)
+	}
+	if len(rawResources) != 1 {
+		t.Fatalf("Error rendering resource, got len %v, expected 1", len(rawResources))
+	}
+	if rawResources[0]["name"] != "t1name" {
+		t.Fatalf("Rendered template error, got %v, expected 't1name'", rawResources[0]["name"])
+	}
+	rawResources, err = template2maps(tmpl[1].Template, tmplValues)
+	if err != nil {
+		t.Fatalf("Error rendering empty resource, got err %v", err)
+	}
+	if len(rawResources) != 0 {
+		t.Fatalf("Error rendering empty resource, got len %v, expected 0", len(rawResources))
+	}
+	rawResources, err = template2maps(tmpl[2].Template, tmplValues)
+	if err != nil {
+		t.Fatalf("Error rendering multi-resource, got err %v", err)
+	}
+	if len(rawResources) != 3 {
+		t.Fatalf("Error rendering multi-resource, got len %v, expected 3", len(rawResources))
+	}
+}
+
+func TestTemplate2Unstructured(t *testing.T) {
+	tmpl, err := helperGetResourceState()
+	tmplValues := helperGetValues()
+	u, err := template2Unstructured(tmpl[0].Template, tmplValues)
+	if u == nil {
+		t.Fatalf("Cannot render template to map: %v", err)
+	}
+	u, err = template2Unstructured(tmpl[1].Template, tmplValues)
+	if err != nil {
+		t.Fatalf("Error rendering empty resource, got err %v", err)
+	}
+	if len(u) != 0 {
+		t.Fatalf("Error rendering empty resource, got %v, expected 0", len(u))
+	}
+	u, err = template2Unstructured(tmpl[2].Template, tmplValues)
+	if err != nil {
+		t.Fatalf("Error rendering multi-resource, got err %v", err)
+	}
+	if len(u) != 3 {
+		t.Fatalf("Error rendering multi-resource, got len %v, expected 3", len(u))
+	}
+}

--- a/doc/creating-gatewayclass-definitions.md
+++ b/doc/creating-gatewayclass-definitions.md
@@ -80,13 +80,13 @@ function.
 
 Typically templates will result in a single resource, but conditionals
 and loops may result in templates rendering to zero or more than one
-resource. This is supported, but should be used wit caution.
+resource. This is supported but should be used with caution.
 
 Consideration for multi-resource templates:
 
 - Resources should be separated by a line with `---` (like in Helm).
 
-- The template as a whole is single unit in the graph of resources,
+- The template as a whole is a single unit in the graph of resources,
   i.e. individual resources in a template cannot refer to each other
   using the `.Resources` method described below. References across
   templates using multiple resources are supported.

--- a/test/e2e/controller_self_test.go
+++ b/test/e2e/controller_self_test.go
@@ -79,7 +79,7 @@ spec:
       template: |
         addresses:
         - type: IPAddress
-          value: {{ .Resources.configMapTestSource.data.testIPAddress }}
+          value: {{ (index .Resources.configMapTestSource 0).data.testIPAddress }}
     resourceTemplates:
       childGateway: |
         apiVersion: gateway.networking.k8s.io/v1beta1


### PR DESCRIPTION
**Description**

Enable support for templates with conditionals and loops. Currently a template must render to exactly one resource. This PR changes this, such that templates may render to zero, one or more resources which is an enabled for using e.g. `if` and `range` in templates.

The tests in `controllers/gateway_controller_test.go` illustrates well this new feature.

Fixes #155 

**Checklist**

- [x] Unit tests updated
- [x] End user documentation updated
- [NA] If changes apply to Helm chart, a note have been made in the 'UNRELEASED' section of the charts CHANGELOG.md
