### PR TITLE
test: change getting started test to use recent/local version of blueprints

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -240,7 +240,7 @@ undeploy-aws-istio-blueprint-local:
 #################
 # See 'doc/getting-started.md'
 .PHONY: setup-getting-started
-setup-getting-started: setup-getting-started-cluster setup-getting-started-controller setup-getting-started-controller-blueprint deploy-getting-started-usecase
+setup-getting-started: setup-getting-started-cluster setup-getting-started-controller deploy-controller-blueprint-local deploy-getting-started-usecase
 
 .PHONY: setup-getting-started-cluster
 setup-getting-started-cluster:


### PR DESCRIPTION
**Description**

This PR changes the workflow imitating the getting-started guide to use the local version of blueprints instead of a fixed release version. This change is necessary to test if a PR have changes to blueprints and coordinated changes to controller and blueprints (i.e. controller have been updated and no longer is compatible with previously released blueprints but is compatible with local version).
