### PR TITLE
Feature/istio 17

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -70,7 +70,7 @@ delete-cluster:
 	kind delete cluster --name kind-gwc-dev-cluster
 
 #################
-ISTIO_VERSION ?= 1.16.1
+ISTIO_VERSION ?= 1.17.2
 
 .PHONY: deploy-istio
 deploy-istio:
@@ -231,7 +231,7 @@ undeploy-aws-istio-blueprint:
 
 .PHONY: deploy-aws-istio-blueprint-local
 deploy-aws-istio-blueprint-local:
-	kubectl apply -f blueprints/gatewayclassblueprint-aws-alb-crossplane.yaml -f blueprints/gatewayclass-aws-alb-crossplane.yaml
+	kubectl apply -f blueprints/aws-alb-crossplane/gatewayclassblueprint-aws-alb-crossplane.yaml -f blueprints/aws-alb-crossplane/gatewayclass-aws-alb-crossplane.yaml
 
 .PHONY: undeploy-aws-istio-blueprint-local
 undeploy-aws-istio-blueprint-local:

--- a/blueprints/aws-alb-crossplane/gatewayclassblueprint-aws-alb-crossplane.yaml
+++ b/blueprints/aws-alb-crossplane/gatewayclassblueprint-aws-alb-crossplane.yaml
@@ -156,7 +156,7 @@ spec:
           targetGroupARN: {{ (index .Resources.LBTargetGroup 0).status.atProvider.arn }}
           targetType: ip
           serviceRef:
-            name: {{ .Gateway.metadata.name }}-child
+            name: {{ .Gateway.metadata.name }}-child-istio
             port: 80
       SecurityGroup: |
         apiVersion: ec2.aws.upbound.io/v1beta1

--- a/blueprints/contour-istio/gatewayclassblueprint-contour-istio-cert.yaml
+++ b/blueprints/contour-istio/gatewayclassblueprint-contour-istio-cert.yaml
@@ -60,7 +60,7 @@ spec:
                 pathType: Prefix
                 backend:
                   service:
-                    name: {{ $.Gateway.metadata.name }}-child
+                    name: {{ $.Gateway.metadata.name }}-child-istio
                     port:
                       number: 80
           {{- end }}

--- a/blueprints/contour-istio/gatewayclassblueprint-contour-istio.yaml
+++ b/blueprints/contour-istio/gatewayclassblueprint-contour-istio.yaml
@@ -53,7 +53,7 @@ spec:
                 pathType: Prefix
                 backend:
                   service:
-                    name: {{ $.Gateway.metadata.name }}-child
+                    name: {{ $.Gateway.metadata.name }}-child-istio
                     port:
                       number: 80
           {{- end }}


### PR DESCRIPTION
**Description**

This PR updates the aws-crossplane blueprint to be compatible with the naming convention change in Istio 1.17: https://istio.io/latest/news/releases/1.17.x/announcing-1.17/change-notes/

The change is basically that Istio adds the istio gatewayclass name as a suffix, hence the core change (beside compatibility test updates) is changes like:

```
- name: {{ .Gateway.metadata.name }}-child
+ name: {{ .Gateway.metadata.name }}-child-istio
```

The version compatibility list has updated and a tentative version `0.0.21` has been marked as compatible with Istio 1.17, i.e. when this PR is merged we can create a `0.0.21` release.