### PR TITLE
Feature/https redirect

### DIFF
--- a/blueprints/aws-alb-crossplane/gatewayclassblueprint-aws-alb-crossplane.yaml
+++ b/blueprints/aws-alb-crossplane/gatewayclassblueprint-aws-alb-crossplane.yaml
@@ -14,7 +14,6 @@ spec:
       ingressAcls:
         cidrs:
         - 0.0.0.0/0
-        port: 443
       tags: []
     # Values required by this blueprint without defaults:
     #   providerConfigName: "example-crossplane-provider-name"
@@ -115,6 +114,33 @@ spec:
               {{- toYaml .Values.tags | nindent 6 }}
             {{ end }}
             targetType: ip
+      LBListenerRedirHttps: |
+        apiVersion: elbv2.aws.upbound.io/v1beta1
+        kind: LBListener
+        metadata:
+          labels:
+            tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+          name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}-redir
+        spec:
+          providerConfigRef:
+            name: {{ .Values.providerConfigName }}
+          forProvider:
+            region: {{ .Values.region }}
+            port: 80
+            protocol: HTTP
+            defaultAction:
+            - type: redirect
+              redirect:
+              - port: "443"
+                protocol: HTTPS
+                statusCode: HTTP_301
+            loadBalancerArnSelector:
+              matchLabels:
+                tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+            {{ if .Values.tags }}
+            tags:
+              {{- toYaml .Values.tags | nindent 6 }}
+            {{ end }}
       LBListener: |
         apiVersion: elbv2.aws.upbound.io/v1beta1
         kind: LBListener
@@ -221,29 +247,53 @@ spec:
                 tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
             toPort: 15021
             type: egress
-      SecurityGroupRuleIngress: |
+      SecurityGroupRuleIngress80: |
         apiVersion: ec2.aws.upbound.io/v1beta1
         kind: SecurityGroupRule
         metadata:
           labels:
             tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
-          name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}-ingress
+          name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}-ingress80
         spec:
           providerConfigRef:
             name: {{ .Values.providerConfigName }}
           forProvider:
-            description: "External traffic towards ALB"
+            description: "External traffic towards ALB port 80"
             cidrBlocks:
               {{ range .Values.ingressAcls.cidrs -}}
               - {{ . }}
               {{ end }}
-            fromPort: {{ .Values.ingressAcls.port }}
+            fromPort: 80
             protocol: tcp
             region: {{ .Values.region }}
             securityGroupIdSelector:
               matchLabels:
                 tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
-            toPort: {{ .Values.ingressAcls.port }}
+            toPort: 80
+            type: ingress
+      SecurityGroupRuleIngress443: |
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: SecurityGroupRule
+        metadata:
+          labels:
+            tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+          name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}-ingress443
+        spec:
+          providerConfigRef:
+            name: {{ .Values.providerConfigName }}
+          forProvider:
+            description: "External traffic towards ALB port 443"
+            cidrBlocks:
+              {{ range .Values.ingressAcls.cidrs -}}
+              - {{ . }}
+              {{ end }}
+            fromPort: 443
+            protocol: tcp
+            region: {{ .Values.region }}
+            securityGroupIdSelector:
+              matchLabels:
+                tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+            toPort: 443
             type: ingress
       SecurityGroupRuleUpstreamIngress80: |
         apiVersion: ec2.aws.upbound.io/v1beta1

--- a/hack/demo/namespace-gatewayclassconfig.yaml
+++ b/hack/demo/namespace-gatewayclassconfig.yaml
@@ -1,3 +1,4 @@
+# Settings owned by infrastructure provider, tenant cannot modify or override
 apiVersion: gateway.tv2.dk/v1alpha1
 kind: GatewayClassConfig
 metadata:
@@ -5,10 +6,23 @@ metadata:
   namespace: foo-infra
 spec:
   override:
-    certificateArn: $CERTIFICATE_ARN
     providerConfigName: admin
-    #tags:
-    #  tenant: foo-tenant
+    tags:
+      tenant: foo-tenant
+  targetRef:
+    group: ""
+    kind: Namespace
+    name: foo-infra
+---
+# Configuration owned by tenant
+apiVersion: gateway.tv2.dk/v1alpha1
+kind: GatewayConfig
+metadata:
+  name: foo-infra-tenant-defaults
+  namespace: foo-infra
+spec:
+  default:
+    certificateArn: $CERTIFICATE_ARN
   targetRef:
     group: ""
     kind: Namespace


### PR DESCRIPTION
**Description**

This PR Adds redirects from HTTP to HTTPS.

The blueprint previously alloved the HTTPS port to be configured and had a default of 443. With this PR, this feature have been removed. Now redirect from port 80 to 443 and TLS termination on port 443 is hardcoded.

Fixes #154 
