### PR TITLE
Added podAnnotations feature

### DIFF
--- a/.github/configs/ct-lint.yaml
+++ b/.github/configs/ct-lint.yaml
@@ -5,3 +5,4 @@ chart-dirs:
   - charts
 helm-extra-args: --timeout 600s
 validate-maintainers: false
+check-version-increment: false

--- a/charts/bifrost-gateway-controller/CHANGELOG.md
+++ b/charts/bifrost-gateway-controller/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Example text, add your PR info according to example below below this line. Do not bump chart version in Chart.yaml.
+- Added podAnnotations to chart, allowing users to set annotations for the controller pod
 
 ## [0.1.6]
 

--- a/charts/bifrost-gateway-controller/README.md
+++ b/charts/bifrost-gateway-controller/README.md
@@ -27,6 +27,7 @@ Gateway API driven management of network infrastructure across Kubernetes and cl
 | controllerManager.manager.resources.limits.memory | string | `"128Mi"` |  |
 | controllerManager.manager.resources.requests.cpu | string | `"10m"` |  |
 | controllerManager.manager.resources.requests.memory | string | `"64Mi"` |  |
+| controllerManager.podAnnotations | object | `{}` |  |
 | controllerManager.replicas | int | `1` |  |
 | metricsService.ports[0].name | string | `"http"` |  |
 | metricsService.ports[0].port | int | `8080` |  |

--- a/charts/bifrost-gateway-controller/ci/with-additional-annotations-values.yaml
+++ b/charts/bifrost-gateway-controller/ci/with-additional-annotations-values.yaml
@@ -1,3 +1,5 @@
 controllerManager:
   annotations:
-    tv2.dk/gateway-controller/annontations: true
+    tv2.dk/gateway-controller/annotations: true
+  podAnnotations:
+    tv2.dk/gateway-controller/podAnnotations: true

--- a/charts/bifrost-gateway-controller/templates/deployment.yaml
+++ b/charts/bifrost-gateway-controller/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         control-plane: manager
       {{- include "gateway-controller.selectorLabels" . | nindent 8 }}
       annotations:
+      {{- with .Values.controllerManager.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
         kubectl.kubernetes.io/default-container: manager
     spec:
       containers:

--- a/charts/bifrost-gateway-controller/values.yaml
+++ b/charts/bifrost-gateway-controller/values.yaml
@@ -50,6 +50,10 @@ controllerManager:
 
   # Annotations to add to the deployment
   annotations: {}
+
+  # Annotations to add to the pod
+  podAnnotations: {}
+
   replicas: 1
 
   deploymentStrategy:


### PR DESCRIPTION
**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements -->
Allows users of the helm chart to set podAnnotations. Useful if someone wants to eg. set datadog annotations on the controller pod 

**Checklist**

- [X] Unit tests updated
- [X] End user documentation updated
- [X] If changes apply to Helm chart, a note have been made in the 'UNRELEASED' section of the charts CHANGELOG.md
