### PR TITLE
Helm chart image tag default to Chart.appVersion instead of latest

### DIFF
--- a/charts/bifrost-gateway-controller/CHANGELOG.md
+++ b/charts/bifrost-gateway-controller/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [UNRELEASED]
 
 - Example text, add your PR info according to example below below this line. Do not bump chart version in Chart.yaml.
+- chart image tag default to Chart.appVersion instead of latest. ([#194](https://github.com/tv2-oss/bifrost-gateway-controller/pull/194)) [@michaelvl](https://github.com/michaelvl)
 
 ## [0.1.7]
 

--- a/charts/bifrost-gateway-controller/Chart.yaml
+++ b/charts/bifrost-gateway-controller/Chart.yaml
@@ -3,4 +3,4 @@ name: bifrost-gateway-controller-helm
 description: Gateway API driven management of network infrastructure across Kubernetes and cloud infrastructure
 type: application
 version: 0.1.7
-appVersion: "0.0.13"
+appVersion: "0.0.21"

--- a/charts/bifrost-gateway-controller/README.md
+++ b/charts/bifrost-gateway-controller/README.md
@@ -1,6 +1,6 @@
 # bifrost-gateway-controller-helm
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.13](https://img.shields.io/badge/AppVersion-0.0.13-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.21](https://img.shields.io/badge/AppVersion-0.0.21-informational?style=flat-square)
 
 Gateway API driven management of network infrastructure across Kubernetes and cloud infrastructure
 
@@ -13,7 +13,7 @@ Gateway API driven management of network infrastructure across Kubernetes and cl
 | controllerManager.manager.image.name | string | `"bifrost-gateway-controller"` |  |
 | controllerManager.manager.image.pullPolicy | string | `"IfNotPresent"` |  |
 | controllerManager.manager.image.repository | string | `"ghcr.io/tv2-oss"` |  |
-| controllerManager.manager.image.tag | string | `"latest"` |  |
+| controllerManager.manager.image.tag | string | `""` | Image tag. Defaults to `.Chart.appVersion` |
 | controllerManager.manager.livenessProbe.httpGet.path | string | `"/healthz"` |  |
 | controllerManager.manager.livenessProbe.httpGet.port | int | `8081` |  |
 | controllerManager.manager.livenessProbe.initialDelaySeconds | int | `15` |  |

--- a/charts/bifrost-gateway-controller/templates/deployment.yaml
+++ b/charts/bifrost-gateway-controller/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         {{- if (contains "sha256:" .Values.controllerManager.manager.image.tag) }}
         image: "{{ .Values.controllerManager.manager.image.repository }}/{{ .Values.controllerManager.manager.image.name }}@{{ .Values.controllerManager.manager.image.tag }}"
           {{- else }}
-        image: "{{ .Values.controllerManager.manager.image.repository }}/{{ .Values.controllerManager.manager.image.name }}:{{ .Values.controllerManager.manager.image.tag }}"
+        image: "{{ .Values.controllerManager.manager.image.repository }}/{{ .Values.controllerManager.manager.image.name }}:{{ default .Chart.AppVersion .Values.controllerManager.manager.image.tag }}"
           {{- end }}
         imagePullPolicy: {{ .Values.controllerManager.manager.image.pullPolicy }}
         name: manager

--- a/charts/bifrost-gateway-controller/values.yaml
+++ b/charts/bifrost-gateway-controller/values.yaml
@@ -7,7 +7,8 @@ controllerManager:
     image:
       repository: ghcr.io/tv2-oss
       name: bifrost-gateway-controller
-      tag: latest
+      # -- Image tag. Defaults to `.Chart.appVersion`
+      tag: ""
       pullPolicy: IfNotPresent
 
     resources:


### PR DESCRIPTION
**Description**

Make helm chart deployment image tag default to `.Chart.appVersion` instead of latests. Update `appVersion` to `0.0.21`

<!-- Please link to all GitHub issue that this pull request implements -->
Fixes #122

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
- [x] If changes apply to Helm chart, a note have been made in the 'UNRELEASED' section of the charts CHANGELOG.md
