### PR TITLE
Add json log support to helm chart

### DIFF
--- a/charts/bifrost-gateway-controller/CHANGELOG.md
+++ b/charts/bifrost-gateway-controller/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [UNRELEASED]
 
 - Example text, add your PR info according to example below below this line. Do not bump chart version in Chart.yaml.
-- chart image tag default to Chart.appVersion instead of latest. ([#194](https://github.com/tv2-oss/bifrost-gateway-controller/pull/194)) [@michaelvl](https://github.com/michaelvl)
+- Add json log support to helm chart ([#195](https://github.com/tv2-oss/bifrost-gateway-controller/pull/195)) [@michaelvl](https://github.com/michaelvl)
+- Chart image tag default to Chart.appVersion instead of latest. ([#194](https://github.com/tv2-oss/bifrost-gateway-controller/pull/194)) [@michaelvl](https://github.com/michaelvl)
 
 ## [0.1.7]
 

--- a/charts/bifrost-gateway-controller/README.md
+++ b/charts/bifrost-gateway-controller/README.md
@@ -18,6 +18,8 @@ Gateway API driven management of network infrastructure across Kubernetes and cl
 | controllerManager.manager.livenessProbe.httpGet.port | int | `8081` |  |
 | controllerManager.manager.livenessProbe.initialDelaySeconds | int | `15` |  |
 | controllerManager.manager.livenessProbe.periodSeconds | int | `20` |  |
+| controllerManager.manager.logging.format | string | `"json"` | Logging format. Defaults to text |
+| controllerManager.manager.logging.level | string | `"debug"` | Log level [debug|info|error] |
 | controllerManager.manager.rbac.additionalPermissions | list | `[]` |  |
 | controllerManager.manager.readinessProbe.httpGet.path | string | `"/readyz"` |  |
 | controllerManager.manager.readinessProbe.httpGet.port | int | `8081` |  |

--- a/charts/bifrost-gateway-controller/templates/deployment.yaml
+++ b/charts/bifrost-gateway-controller/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
       containers:
       - args:
         - --leader-elect
+        - --zap-log-level={{ .Values.controllerManager.manager.logging.level }}
+        {{ if eq .Values.controllerManager.manager.logging.format "json" -}}
+        - --zap-devel=false
+        {{- end }}
         command:
         - /bifrost-gateway-controller
         {{- if (contains "sha256:" .Values.controllerManager.manager.image.tag) }}

--- a/charts/bifrost-gateway-controller/values.schema.json
+++ b/charts/bifrost-gateway-controller/values.schema.json
@@ -50,6 +50,20 @@
                         "livenessProbe": {
                             "type": "object"
                         },
+                        "logging": {
+                            "required": [
+                                "format",
+                                "level"
+                            ],
+                            "properties": {
+                                "format": {
+                                    "type": "string"
+                                },
+                                "level": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "readinessProbe": {
                             "type": "object"
                         },

--- a/charts/bifrost-gateway-controller/values.yaml
+++ b/charts/bifrost-gateway-controller/values.yaml
@@ -19,6 +19,12 @@ controllerManager:
         cpu: 10m
         memory: 64Mi
 
+    logging:
+      # -- Logging format. Defaults to text
+      format: json
+      # -- Log level [debug|info|error]
+      level: debug
+
     livenessProbe:
       httpGet:
         path: /healthz


### PR DESCRIPTION
**Description**

Update helm chart to support log configuration, e.g. log format and level. The logger used has the concept of a 'development' and 'production' logger. The former using text format and the latter json. This PR updates the chart to default to specifying the 'production'/json log format.

<!-- Please link to all GitHub issue that this pull request implements -->
Fixes #193 

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
- [x] If changes apply to Helm chart, a note have been made in the 'UNRELEASED' section of the charts CHANGELOG.md
