### PR TITLE
test: add kube-state-metrics deployment

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -114,6 +114,7 @@ deploy-metrics-server:
 #################
 .PHONY: deploy-kube-state-metrics
 deploy-kube-state-metrics:
+	helm upgrade -i --repo https://prometheus-community.github.io/helm-charts prometheus-operator-crds prometheus-operator-crds --version 4.0.2
 	helm upgrade -i --repo https://prometheus-community.github.io/helm-charts kube-state-metrics kube-state-metrics --version 5.7.0 -n kube-system --values test-data/kube-state-metrics-values.yaml
 
 #################

--- a/Makefile.local
+++ b/Makefile.local
@@ -112,6 +112,11 @@ deploy-metrics-server:
 	helm upgrade -i --repo https://kubernetes-sigs.github.io/metrics-server metrics-server metrics-server --version 3.8.3 -n kube-system --set args={--kubelet-insecure-tls}
 
 #################
+.PHONY: deploy-kube-state-metrics
+deploy-kube-state-metrics:
+	helm upgrade -i --repo https://prometheus-community.github.io/helm-charts kube-state-metrics kube-state-metrics --version 5.7.0 -n kube-system --values test-data/kube-state-metrics-values.yaml
+
+#################
 # https://kind.sigs.k8s.io/docs/user/loadbalancer/
 .PHONY: deploy-metallb
 deploy-metallb:

--- a/test-data/kube-state-metrics-values.yaml
+++ b/test-data/kube-state-metrics-values.yaml
@@ -1,3 +1,15 @@
+resources:
+  limits:
+   cpu: 100m
+   memory: 64Mi
+  requests:
+   cpu: 10m
+   memory: 32Mi
+
+prometheus:
+  monitor:
+    enabled: true
+
 rbac:
   extraRules:
   - apiGroups: ["apiextensions.k8s.io"]
@@ -6,11 +18,39 @@ rbac:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["*"]
     verbs: ["list", "watch"]
+
 extraArgs:
 - --custom-resource-state-config
 -  |
     spec:
       resources:
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            version: "v1beta1"
+            kind: GatewayClass
+          metricNamePrefix: "gatewayapi"
+          labelsFromPath:
+            name: ["metadata", "name"]
+            namespace: ["metadata", "namespace"]
+            controllerName: ["spec", "controllerName"]
+          metrics:
+            - name: gatewayclass_conditions
+              help: "GatewayClass conditions"
+              each:
+                type: Gauge
+                gauge:
+                  path: ["status", "conditions"]
+                  labelsFromPath:
+                    type: ["type"]
+                  valueFrom: ["status"]
+            # Zombie GatewayClasses can be detected by comparing `gatewayclass_conditions` with this
+            - name: gatewayclass_info
+              help: "GatewayClass info"
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    classname: ["spec", "controllerName"]
         - groupVersionKind:
             group: gateway.networking.k8s.io
             version: "v1beta1"
@@ -31,8 +71,8 @@ extraArgs:
                     type: ["type"]
                   valueFrom: ["status"]
             # Zombie Gateways can be detected by comparing `gateway_conditions` with this
-            - name: gateway_class_info
-              help: "Gateways class"
+            - name: gateway_info
+              help: "Gateway info"
               each:
                 type: Info
                 info:

--- a/test-data/kube-state-metrics-values.yaml
+++ b/test-data/kube-state-metrics-values.yaml
@@ -1,0 +1,68 @@
+rbac:
+  extraRules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["*"]
+    verbs: ["list", "watch"]
+extraArgs:
+- --custom-resource-state-config
+-  |
+    spec:
+      resources:
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            version: "v1beta1"
+            kind: Gateway
+          metricNamePrefix: "gatewayapi"
+          labelsFromPath:
+            name: ["metadata", "name"]
+            namespace: ["metadata", "namespace"]
+            classname: ["spec", "gatewayClassName"]
+          metrics:
+            - name: gateway_conditions
+              help: "Gateway conditions"
+              each:
+                type: Gauge
+                gauge:
+                  path: ["status", "conditions"]
+                  labelsFromPath:
+                    type: ["type"]
+                  valueFrom: ["status"]
+            # Zombie Gateways can be detected by comparing `gateway_conditions` with this
+            - name: gateway_class_info
+              help: "Gateways class"
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    classname: ["spec", "gatewayClassName"]
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            version: "v1beta1"
+            kind: HTTPRoute
+          metricNamePrefix: "gatewayapi"
+          labelsFromPath:
+            name: ["metadata", "name"]
+            namespace: ["metadata", "namespace"]
+          metrics:
+            - name: httproute_conditions
+              help: "HTTPRoute conditions"
+              each:
+                type: Gauge
+                gauge:
+                  # This will not work for HTTPRoutes attached to multiple parents
+                  path: ["status", "parents", "0", "conditions"]
+                  labelsFromPath:
+                    type: ["type"]
+                  valueFrom: ["status"]
+            # Zombie HTTPRoutes can be detected by comparing `httproute_conditions` with this
+            - name: httproute_info
+              help: "HTTPRoute "
+              each:
+                type: Info
+                info:
+                  labelsFromPath:
+                    classname: ["spec", "parentRefs", "0"]
+- --custom-resource-state-only=true


### PR DESCRIPTION
**Description**

This PR is purely a test-harness additions. It adds a deployment of kube-state-metrics configured to report gateway api resource info.

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
- [ ] If changes apply to Helm chart, a note have been made in the 'UNRELEASED' section of the charts CHANGELOG.md
