### PR TITLE
Document observability

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -40,3 +40,24 @@ helm upgrade -i bifrost-gateway-controller-helm oci://ghcr.io/tv2-oss/bifrost-ga
 In addition to the *bifrost-gateway-controller*, you will need
 blueprints defining datapath implementations. See [Example
 GatewayClassBlueprints](../blueprints/README.md).
+
+## Metrics and Observability
+
+The controller provides [standard controller
+metrics](https://book.kubebuilder.io/reference/metrics-reference.html)
+and the Helm chart provides a
+[ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitor)
+for integration with systems that understand these.
+
+Observability of Gateway-API resources is possbile through [Custom
+Resource State
+Metrics](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/customresourcestate-metrics.md)
+through kube-state-metrics. An example configuration for deploying
+kube-state-metrics is [provided
+here](test-data/kube-state-metrics-values.yaml). Generally, this
+configuration provides condition status for `GatewayClass`, `Gateway`
+and `HTTPRoute` resources.
+
+An SLI for e.g. `Gateway` resources can be created from the metric
+`gateway_conditions` and watching for `Gateway`s without the
+`Programmed` condition.

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -49,7 +49,7 @@ and the Helm chart provides a
 [ServiceMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitor)
 for integration with systems that understand these.
 
-Observability of Gateway-API resources is possbile through [Custom
+Observability of Gateway-API resources is possible through [Custom
 Resource State
 Metrics](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/customresourcestate-metrics.md)
 through kube-state-metrics. An example configuration for deploying

--- a/test-data/kube-state-metrics-values.yaml
+++ b/test-data/kube-state-metrics-values.yaml
@@ -1,3 +1,5 @@
+collectors: []
+
 resources:
   limits:
    cpu: 100m


### PR DESCRIPTION
**Description**

This PR provides documentation on gateway-api observability.

The `collectors: []` is not strictly not necessary, but since the example values file also set `--custom-resource-state-only=true` the resulting configuration is more clear.

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
- [ ] If changes apply to Helm chart, a note have been made in the 'UNRELEASED' section of the charts CHANGELOG.md
