### PR TITLE
Update Crossplane test to use aws provider family

### DIFF
--- a/Makefile.local
+++ b/Makefile.local
@@ -70,7 +70,7 @@ delete-cluster:
 	kind delete cluster --name kind-gwc-dev-cluster
 
 #################
-ISTIO_VERSION ?= 1.17.2
+ISTIO_VERSION ?= 1.18.0
 
 .PHONY: deploy-istio
 deploy-istio:
@@ -185,7 +185,7 @@ undeploy-aws-load-balancer-controller:
 	helm uninstall -n kube-system aws-load-balancer-controller
 
 #################
-CROSSPLANE_VERSION ?= v1.11.0
+CROSSPLANE_VERSION ?= v1.12.2
 
 .PHONY: deploy-crossplane
 deploy-crossplane:
@@ -195,7 +195,7 @@ deploy-crossplane:
 undeploy-crossplane:
 	helm uninstall crossplane -n crossplane-system
 
-CROSSPLANE_AWS_PROVIDER_VERSION ?= v0.28.0
+CROSSPLANE_AWS_PROVIDER_VERSION ?= v0.36.0
 # Note, templates also require CROSSPLANE_INITIAL_IAM_ROLE_ARN and CROSSPLANE_IAM_ROLE_ARN
 
 .PHONY: deploy-crossplane-aws-provider
@@ -203,8 +203,8 @@ deploy-crossplane-aws-provider:
 	cat test-data/crossplane-aws-provider.yaml_tpl | CROSSPLANE_AWS_PROVIDER_VERSION=${CROSSPLANE_AWS_PROVIDER_VERSION} CROSSPLANE_INITIAL_IAM_ROLE_ARN=${CROSSPLANE_INITIAL_IAM_ROLE_ARN} envsubst > crossplane-aws-provider.yaml
 	cat test-data/crossplane-aws-provider-config.yaml_tpl | CROSSPLANE_IAM_ROLE_ARN=${CROSSPLANE_IAM_ROLE_ARN} envsubst > crossplane-aws-provider-config.yaml
 	kubectl apply -f crossplane-aws-provider.yaml
-	kubectl wait "providers.pkg.crossplane.io/provider-aws" --for=condition=Installed --timeout=180s
-	kubectl wait "providers.pkg.crossplane.io/provider-aws" --for=condition=Healthy --timeout=180s
+	kubectl wait "providers.pkg.crossplane.io/provider-family-aws" --for=condition=Installed --timeout=180s
+	kubectl wait "providers.pkg.crossplane.io/provider-family-aws" --for=condition=Healthy --timeout=180s
 	kubectl apply -f crossplane-aws-provider-config.yaml
 
 .PHONY: undeploy-crossplane-aws-provider
@@ -232,7 +232,7 @@ undeploy-controller-helm:
 	helm uninstall -n bifrost-gateway-controller-system bifrost-gateway-controller-helm
 
 #################
-BIFROST_BLUEPRINTS_VERSION ?= 0.0.19
+BIFROST_BLUEPRINTS_VERSION ?= 0.0.21
 
 .PHONY: deploy-controller-blueprint
 setup-getting-started-controller-blueprint:

--- a/blueprints/aws-alb-crossplane/README.md
+++ b/blueprints/aws-alb-crossplane/README.md
@@ -47,8 +47,11 @@ Upbound AWS provider and Istio versions has been verified:
 | `0.0.19` | `v0.33.0` | `v1.11.0` | `1.16.1` | :heavy_check_mark: |
 | `0.0.20` | `v0.33.0` | `v1.11.0` | `1.17.2` | :x: (*) |
 | `0.0.21` | `v0.33.0` | `v1.11.0` | `1.17.2` | :heavy_check_mark: |
+| `0.0.21` | `v0.36.0` | `v1.12.2` | `1.18.0` | :heavy_check_mark: (**) |
 
 (*) In Istio [1.17.0 Gateway naming convention was changed](https://istio.io/latest/news/releases/1.17.x/announcing-1.17/change-notes/) to be a concatenation of Gateway `Name` and `GatewayClass`.
+
+(**) From this time, we switched from using a monolothic AWS provider to using provider families. Details are in make target `deploy-crossplane-aws-provider`.
 
 ## Testing AWS/Crossplane/Istio Blueprint
 
@@ -81,16 +84,16 @@ Deploy dependencies with the make targets shown below. Version information can b
 make deploy-gateway-api
 make deploy-aws-load-balancer-controller-crds
 AWS_LOAD_BALANCER_CONTROLLER_CHART_VERSION=v1.4.6  make deploy-aws-load-balancer-controller
-CROSSPLANE_VERSION=v1.11.0                         make deploy-crossplane
-CROSSPLANE_AWS_PROVIDER_VERSION=v0.33.0            make deploy-crossplane-aws-provider
-ISTIO_VERSION=1.17.2                               make deploy-istio
+CROSSPLANE_VERSION=v1.12.2                         make deploy-crossplane
+CROSSPLANE_AWS_PROVIDER_VERSION=v0.36.0            make deploy-crossplane-aws-provider
+ISTIO_VERSION=1.18.0                               make deploy-istio
 ```
 
 Deploy controller and blueprint:
 
 ```
-BIFROST_VERSION=0.1.6              make deploy-controller-aws-helm
-BIFROST_BLUEPRINTS_VERSION=0.0.18  make deploy-aws-istio-blueprint
+BIFROST_VERSION=0.1.8              make deploy-controller-aws-helm
+BIFROST_BLUEPRINTS_VERSION=0.0.21  make deploy-aws-istio-blueprint
 ```
 
 Note, there is also a `deploy-aws-istio-blueprint-local` make target to deploy

--- a/test-data/crossplane-aws-provider.yaml_tpl
+++ b/test-data/crossplane-aws-provider.yaml_tpl
@@ -20,7 +20,6 @@ spec:
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
-  #name: upbound-provider-aws-ec2
   name: provider-aws-ec2
 spec:
   package: xpkg.upbound.io/upbound/provider-aws-ec2:$CROSSPLANE_AWS_PROVIDER_VERSION
@@ -30,7 +29,6 @@ spec:
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
-  #name: upbound-provider-aws-elbv2
   name: provider-aws-elbv2
 spec:
   package: xpkg.upbound.io/upbound/provider-aws-elbv2:$CROSSPLANE_AWS_PROVIDER_VERSION

--- a/test-data/crossplane-aws-provider.yaml_tpl
+++ b/test-data/crossplane-aws-provider.yaml_tpl
@@ -11,8 +11,29 @@ spec:
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
-  name: provider-aws
+  name: provider-family-aws
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws:$CROSSPLANE_AWS_PROVIDER_VERSION
+  package: xpkg.upbound.io/upbound/provider-family-aws:$CROSSPLANE_AWS_PROVIDER_VERSION
   controllerConfigRef:
     name: aws-config
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  #name: upbound-provider-aws-ec2
+  name: provider-aws-ec2
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-ec2:$CROSSPLANE_AWS_PROVIDER_VERSION
+  controllerConfigRef:
+    name: aws-config
+---
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  #name: upbound-provider-aws-elbv2
+  name: provider-aws-elbv2
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-elbv2:$CROSSPLANE_AWS_PROVIDER_VERSION
+  controllerConfigRef:
+    name: aws-config
+---


### PR DESCRIPTION
**Description**

This PR updates the Crossplane integration test to use aws-provider-family and specifically the ec2 nd elbv2 providers.

**Checklist**

- [ ] Unit tests updated
- [x] End user documentation updated
- [ ] If changes apply to Helm chart, a note have been made in the 'UNRELEASED' section of the charts CHANGELOG.md
