### PR TITLE
Fix empty status message. Rename Resource field

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -337,3 +337,7 @@ func patchUnstructured(ctx context.Context, r ControllerDynClient, us *unstructu
 	}
 	return err
 }
+
+func PtrTo[T any](val T) *T {
+	return &val
+}

--- a/controllers/gateway_controller_test.go
+++ b/controllers/gateway_controller_test.go
@@ -388,7 +388,7 @@ var _ = Describe("Gateway controller non-ready resources", func() {
 				}
 				if !conditionStateIs(gwRead, "Accepted", PtrTo(metav1.ConditionTrue), nil, nil) ||
 					!conditionStateIs(gwRead, "Ready", PtrTo(metav1.ConditionFalse), nil, nil) ||
-					!conditionStateIs(gwRead, "Programmed", PtrTo(metav1.ConditionFalse), PtrTo("Pending"), PtrTo("Xmissing 1 resources: configMapTestIntermediate1\\[\\]")) {
+					!conditionStateIs(gwRead, "Programmed", PtrTo(metav1.ConditionFalse), PtrTo("Pending"), PtrTo("missing 1 resources: configMapTestIntermediate1\\[\\]")) {
 					return false
 				}
 				return true
@@ -397,7 +397,7 @@ var _ = Describe("Gateway controller non-ready resources", func() {
 	})
 })
 
-func conditionStateIs(gw *gatewayapi.Gateway, condType string, status *metav1.ConditionStatus, reason *string, messageRegEx *string) bool {
+func conditionStateIs(gw *gatewayapi.Gateway, condType string, status *metav1.ConditionStatus, reason, messageRegEx *string) bool {
 	var msgMatch *regexp.Regexp
 	if messageRegEx != nil {
 		msgMatch, _ = regexp.Compile(*messageRegEx)

--- a/controllers/statuscheck.go
+++ b/controllers/statuscheck.go
@@ -42,7 +42,7 @@ import (
 // `Ready` status condition, which is implemented through kstatus.
 func statusIsReady(templates []*ResourceTemplateState) (bool, error) {
 	for _, tmpl := range templates {
-		for _, res := range tmpl.NewResources {
+		for _, res := range tmpl.Resources {
 			if res.Current == nil {
 				return false, nil
 			}
@@ -62,9 +62,14 @@ func statusIsReady(templates []*ResourceTemplateState) (bool, error) {
 func statusExistingTemplates(templates []*ResourceTemplateState) []string {
 	var missing []string
 	for _, tmpl := range templates {
-		for resIdx, res := range tmpl.NewResources {
-			if res.Current == nil {
-				missing = append(missing, fmt.Sprintf("%s[%d]", tmpl.TemplateName, resIdx))
+		if len(tmpl.Resources) == 0 {
+			// No resources - we treat this an e.g. a render error and mark the unknown resulting number of resources with '[]'
+			missing = append(missing, fmt.Sprintf("%s[]", tmpl.TemplateName))
+		} else {
+			for resIdx, res := range tmpl.Resources {
+				if res.Current == nil {
+					missing = append(missing, fmt.Sprintf("%s[%d]", tmpl.TemplateName, resIdx))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**Description**

A common situation where the status message was empty were in the case of template rendering errors. The previous version of the code did not handle this - it only handled apply errrors, i.e. errors encountered after a succesfull rendering.

This PR also implements a FIXME, the renaming of the `NewResources` to `Resources` in the `ResourceTemplateState` struct.

Fixes #213

**Checklist**

- [x] Unit tests updated
- [ ] End user documentation updated
- [ ] If changes apply to Helm chart, a note have been made in the 'UNRELEASED' section of the charts CHANGELOG.md
