### PR TITLE
Limited character for name of targetgroup in GatewayClassBlueprint

### DIFF
--- a/blueprints/aws-alb-crossplane/README.md
+++ b/blueprints/aws-alb-crossplane/README.md
@@ -32,6 +32,10 @@ This definition is provided in the following files:
 - [`gatewayclassblueprint-crossplane-aws-alb-values.yaml`](../../charts/bifrost-gateway-controller/ci/gatewayclassblueprint-crossplane-aws-alb-values.yaml)
 RBAC for bifrost-gateway-controller Helm deployment suited for the `aws-alb-crossplane` blueprint.
 
+### TargetGroup name limit
+
+The `TargetGroup` resource in AWS has a character limit of 32 in AWS. This doesn't leave a lot of room for identifiers in the name. For this reason, the generated name (the format of which is `gw-<NAMESPACE>-<NAME>`) will be cut off at 25 characters, and then appended with the first 6 characters of the SHA1 of the entire name. This should ensure uniqueness of names, while also forcing conforming to the 32 character limit.
+
 ## Compatibility
 
 This blueprint use AWS Crossplane resources through the [Upbound AWS

--- a/blueprints/aws-alb-crossplane/README.md
+++ b/blueprints/aws-alb-crossplane/README.md
@@ -36,6 +36,8 @@ RBAC for bifrost-gateway-controller Helm deployment suited for the `aws-alb-cros
 
 The `TargetGroup` resource in AWS has a character limit of 32 in AWS. This doesn't leave a lot of room for identifiers in the name. For this reason, the generated name (the format of which is `gw-<NAMESPACE>-<NAME>`) will be cut off at 25 characters, and then appended with the first 6 characters of the SHA1 of the entire name. This should ensure uniqueness of names, while also forcing conforming to the 32 character limit.
 
+Because of this method, the name of `TargetGroups` might not always contain the full `name` and `namespace` of the corresponding Kubernetes resource. For this reason, these resources in AWS will also be tagged with `bifrost-gateway-controller/targetgroup_name` and `bifrost-gateway-controller/targetgroup_namespace`.
+
 ## Compatibility
 
 This blueprint use AWS Crossplane resources through the [Upbound AWS

--- a/blueprints/aws-alb-crossplane/gatewayclassblueprint-aws-alb-crossplane.yaml
+++ b/blueprints/aws-alb-crossplane/gatewayclassblueprint-aws-alb-crossplane.yaml
@@ -99,12 +99,12 @@ spec:
         metadata:
           labels:
             tv2.dk/gw: {{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
-          name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+          name: {{ printf "gw-%s-%s" .Gateway.metadata.namespace .Gateway.metadata.name | substr 0 25}}-{{ printf "%s-%s" .Gateway.metadata.namespace .Gateway.metadata.name | sha1sum | substr 0 6 }}
         spec:
           providerConfigRef:
             name: {{ .Values.providerConfigName }}
           forProvider:
-            name: gw-{{ .Gateway.metadata.namespace }}-{{ .Gateway.metadata.name }}
+            name: {{ printf "gw-%s-%s" .Gateway.metadata.namespace .Gateway.metadata.name | substr 0 25}}-{{ printf "%s-%s" .Gateway.metadata.namespace .Gateway.metadata.name | sha1sum | substr 0 6 }}
             region: {{ .Values.region }}
             vpcId: {{ .Values.vpcId }}
             healthCheck:

--- a/blueprints/aws-alb-crossplane/gatewayclassblueprint-aws-alb-crossplane.yaml
+++ b/blueprints/aws-alb-crossplane/gatewayclassblueprint-aws-alb-crossplane.yaml
@@ -116,10 +116,12 @@ spec:
               port: {{ .Values.healthCheck.port | quote }}
             port: 80
             protocol: HTTP
-            {{ if .Values.tags }}
             tags:
+              bifrost-gateway-controller/targetgroup_name: {{ .Gateway.metadata.name }}
+              bifrost-gateway-controller/targetgroup_namespace: {{ .Gateway.metadata.namespace }}
+              {{ if .Values.tags }}
               {{- toYaml .Values.tags | nindent 6 }}
-            {{ end }}
+              {{ end }}
             targetType: ip
       LBListenerRedirHttps: |
         apiVersion: elbv2.aws.upbound.io/v1beta1

--- a/hack/demo/delete-gw-cluster-resources.sh
+++ b/hack/demo/delete-gw-cluster-resources.sh
@@ -4,6 +4,7 @@ NS=$1
 GWNAME=$2
 
 NAME=gw-${NS}-${GWNAME}
+TARGETGROUPNAME="$(echo "gw-${NS}-${GWNAME}" | cut -b1-25)-$(echo -n "${NS}-${GWNAME}" | openssl sha1 | cut -b1-6)"
 
 kubectl delete securitygrouprule.ec2.aws.upbound.io/${NAME}-upstream15021
 kubectl delete securitygrouprule.ec2.aws.upbound.io/${NAME}-upstream80
@@ -13,6 +14,6 @@ kubectl delete securitygrouprule.ec2.aws.upbound.io/${NAME}-ingress80
 kubectl delete securitygrouprule.ec2.aws.upbound.io/${NAME}-ingress443
 kubectl delete lblistener.elbv2.aws.upbound.io/${NAME}
 kubectl delete lblistener.elbv2.aws.upbound.io/${NAME}-redir
-kubectl delete lbtargetgroup.elbv2.aws.upbound.io/${NAME}
+kubectl delete lbtargetgroup.elbv2.aws.upbound.io/${TARGETGROUPNAME}
 kubectl delete lb.elbv2.aws.upbound.io/${NAME}
 kubectl delete securitygroup.ec2.aws.upbound.io/${NAME}


### PR DESCRIPTION
**Description**

<!-- Please provide a summary of the change here. -->

<!-- Please link to all GitHub issue that this pull request implements -->
TargetGroups in AWS have a name character limit of 32. The current template generates a name that is `gw-<NAMESPACE>-<NAME>`. This doesn't leave a lot of room in general, and if one deploys the same config to several clusters, then there is very little space for cluster identifiers, eg `cluster-1`.
\
To combat these issues, and issues with accidentally creating TargetGroups with too long names, this PR to the blueprint will cut off name if they are too long, and furthermore suffix names with the first 6 characters of a SHA1, which is generated over the entire name. This should ensure that resources should have different names if they contain their cluster identifier.

**Checklist**

- [N/A] Unit tests updated
- [X] End user documentation updated
- [N/A] If changes apply to Helm chart, a note have been made in the 'UNRELEASED' section of the charts CHANGELOG.md
