### PR TITLE
Fix running goreleaser also using devbox

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -73,7 +73,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run:
-          goreleaser release
+          devbox run -- goreleaser release
 
       - name: Container metadata
         id: meta


### PR DESCRIPTION
This PR fixes goreleaser to also run using devbox.
