### PR TITLE
DCP-265: Go caching in CI workflows

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -22,6 +22,16 @@ jobs:
 
       - uses: jetify-com/devbox-install-action@22b0f5500b14df4ea357ce673fbd4ced940ed6a1 # tag=v0.13.0
 
+      - name: Cache Go modules and build cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Run tests
         run: |
           devbox run -- make test
@@ -41,6 +51,16 @@ jobs:
           fetch-depth: 0
 
       - uses: jetify-com/devbox-install-action@22b0f5500b14df4ea357ce673fbd4ced940ed6a1 # tag=v0.13.0
+
+      - name: Cache Go modules and build cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Login to GitHub Container Registry
         env:

--- a/.github/workflows/chart-lint-and-test.yaml
+++ b/.github/workflows/chart-lint-and-test.yaml
@@ -16,6 +16,16 @@ jobs:
 
       - uses: jetify-com/devbox-install-action@22b0f5500b14df4ea357ce673fbd4ced940ed6a1 # tag=v0.13.0
 
+      - name: Cache Go modules and build cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Verify Helm docs updated
         id: helm-docs
         run: |

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -14,6 +14,16 @@ jobs:
 
       - uses: jetify-com/devbox-install-action@22b0f5500b14df4ea357ce673fbd4ced940ed6a1 # tag=v0.13.0
 
+      - name: Cache Go modules and build cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Setup E2E KIND cluster
         run: |
           devbox run -- make setup-e2e-test-cluster wait-ready-external-dns-test

--- a/.github/workflows/getting-started-usecase.yaml
+++ b/.github/workflows/getting-started-usecase.yaml
@@ -14,6 +14,16 @@ jobs:
 
       - uses: jetify-com/devbox-install-action@22b0f5500b14df4ea357ce673fbd4ced940ed6a1 # tag=v0.13.0
 
+      - name: Cache Go modules and build cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Setup getting-started usecase
         run: |
           devbox run -- make setup-getting-started

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -88,3 +88,4 @@ jobs:
           KO_DOCKER_REPO: ko.local
         run: |
           devbox run -- make container
+

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -14,6 +14,16 @@ jobs:
 
       - uses: jetify-com/devbox-install-action@22b0f5500b14df4ea357ce673fbd4ced940ed6a1 # tag=v0.13.0
 
+      - name: Cache Go modules and build cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Run tests
         run: |
           devbox run -- make test
@@ -37,6 +47,16 @@ jobs:
 
       - uses: jetify-com/devbox-install-action@22b0f5500b14df4ea357ce673fbd4ced940ed6a1 # tag=v0.13.0
 
+      - name: Cache Go modules and build cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Run golangci-lint
         run:
           devbox run -- make lint
@@ -52,6 +72,16 @@ jobs:
           fetch-depth: 0
 
       - uses: jetify-com/devbox-install-action@22b0f5500b14df4ea357ce673fbd4ced940ed6a1 # tag=v0.13.0
+
+      - name: Cache Go modules and build cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Build container image (local only)
         env:


### PR DESCRIPTION
## Summary

Add `actions/cache@v5` to cache Go modules (`~/go/pkg/mod`) and build cache (`~/.cache/go-build`) across all workflow jobs that compile Go code:

- **build-release.yaml**: `tests`, `release`
- **pr-test.yaml**: `tests`, `golangci`, `build-pr`
- **e2e-test.yaml**: `tests`
- **chart-lint-and-test.yaml**: `chart-test`
- **getting-started-usecase.yaml**: `tests`

Cache key is based on `hashFiles("**/go.sum")` with a `restore-keys` fallback for partial hits when dependencies change.

**Main finding**: The Go build times in bifrost-gateway-controller are already short (2-5 min) compared to c8p7-controllers (8.5 min), so cache hit improvements are negligible here — the module download and compilation is not the bottleneck.

## Test Results

| Workflow / Job | Cache miss | Cache hit | Savings |
|---|---|---|---|
| Test PR / `tests` | 2m 07s | 2m 14s | ~0 |
| Test PR / `lint` | 49s | 51s | ~0 |
| Test PR / `build-pr` | 2m 24s | 2m 27s | ~0 |
| E2E-test / `tests` | 3m 51s | 4m 01s | ~0 |
| Getting-started / `tests` | 5m 26s | 5m 20s | ~0 |
| Chart Lint and Test / `chart-test` | 13s | 13s | ~0 |