### PR TITLE
add /ko-app to bin path

### DIFF
--- a/charts/bifrost-gateway-controller/templates/deployment.yaml
+++ b/charts/bifrost-gateway-controller/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - --zap-devel=false
         {{- end }}
         command:
-        - /bifrost-gateway-controller
+        - /ko-app/bifrost-gateway-controller
         {{- if (contains "sha256:" .Values.controller.image.tag) }}
         image: "{{ .Values.controller.image.repository }}/{{ .Values.controller.image.name }}@{{ .Values.controller.image.tag }}"
           {{- else }}


### PR DESCRIPTION
Current containers generate this error:

```
        message: 'failed to create containerd task: failed to create shim task: OCI
          runtime create failed: runc create failed: unable to start container process:
          error during container init: exec: "/bifrost-gateway-controller": stat /bifrost-gateway-controller:
          no such file or directory'
```
