### PR TITLE
bump chart to build new version

### DIFF
--- a/charts/bifrost-gateway-controller/Chart.yaml
+++ b/charts/bifrost-gateway-controller/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: bifrost-gateway-controller-helm
 description: Gateway API driven management of network infrastructure across Kubernetes and cloud infrastructure
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.0.24"

--- a/charts/bifrost-gateway-controller/README.md
+++ b/charts/bifrost-gateway-controller/README.md
@@ -1,6 +1,6 @@
 # bifrost-gateway-controller-helm
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.24](https://img.shields.io/badge/AppVersion-0.0.24-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.24](https://img.shields.io/badge/AppVersion-0.0.24-informational?style=flat-square)
 
 Gateway API driven management of network infrastructure across Kubernetes and cloud infrastructure
 


### PR DESCRIPTION
Forgot to bump chart in this https://github.com/tv2/bifrost-gateway-controller/pull/363

Oddly the CI check didn't fail. This PR bumps the chart version.