### PR TITLE
DCP-267: Improve go tests

### DIFF
--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -75,13 +75,13 @@ func (f *fakeDynControllerClient) DynamicClient() dynamic.Interface { return f.d
 
 // newFakeDynClient creates a new fakeDynControllerClient with the given objects
 // with a reactor that allows ApplyPatchType for unstructured objects.
-func newFakeDynClient(objs ...client.Object) *fakeDynControllerClient {
+func newFakeDynClient(objs ...client.Object) *fakeDynControllerClient { //nolint:unparam // objs is variadic for convenience
 	fc := newFakeClient(objs...)
 	dyn := fakedynamic.NewSimpleDynamicClient(fc.scheme)
 	// The default fake tracker requires objects to exist before Apply;
 	// intercept ApplyPatchType and return the deserialized object directly.
 	dyn.PrependReactor("patch", "*", func(action ktesting.Action) (bool, runtime.Object, error) {
-		pa := action.(ktesting.PatchAction)
+		pa, _ := action.(ktesting.PatchAction)
 		if pa.GetPatchType() != k8stypes.ApplyPatchType {
 			return false, nil, nil
 		}
@@ -254,14 +254,16 @@ var _ = Describe("merge", func() {
 	It("Should overwrite scalar values from 'b' into 'a'", func() {
 		a := map[string]any{"key": "val-a"}
 		b := map[string]any{"key": "val-b"}
-		result := merge(a, b).(map[string]any)
+		result, ok := merge(a, b).(map[string]any)
+		Expect(ok).To(BeTrue())
 		Expect(result["key"]).To(Equal("val-b")) // Expect value from b to overwrite value from a
 	})
 
 	It("Should add new keys from 'b'", func() {
 		a := map[string]any{"key1": "val1"}
 		b := map[string]any{"key2": "val2"}
-		result := merge(a, b).(map[string]any)
+		result, ok := merge(a, b).(map[string]any)
+		Expect(ok).To(BeTrue())
 		Expect(result["key1"]).To(Equal("val1")) // Expect existing key (key1) to remain unchanged
 		Expect(result["key2"]).To(Equal("val2")) // Expect new key (key2) from b to be added
 	})
@@ -269,8 +271,10 @@ var _ = Describe("merge", func() {
 	It("Should merge nested maps", func() {
 		a := map[string]any{"metadata": map[string]any{"onlyInA": "1", "shared": "2"}}
 		b := map[string]any{"metadata": map[string]any{"shared": "3", "onlyInB": "4"}}
-		result := merge(a, b).(map[string]any)
-		metadata := result["metadata"].(map[string]any)
+		result, ok := merge(a, b).(map[string]any)
+		Expect(ok).To(BeTrue())
+		metadata, ok := result["metadata"].(map[string]any)
+		Expect(ok).To(BeTrue())
 		Expect(metadata["onlyInA"]).To(Equal("1")) // Expect existing key to remain unchanged
 		Expect(metadata["shared"]).To(Equal("3"))  // Expect shared key to be overwritten by b
 		Expect(metadata["onlyInB"]).To(Equal("4")) // Expect new key from b to be added
@@ -279,7 +283,8 @@ var _ = Describe("merge", func() {
 	It("Should preserve 'a' on type conflict (map vs scalar)", func() {
 		a := map[string]any{"key": map[string]any{"nested": "value"}}
 		b := map[string]any{"key": "scalar"}
-		result := merge(a, b).(map[string]any)
+		result, ok := merge(a, b).(map[string]any)
+		Expect(ok).To(BeTrue())
 		Expect(result["key"]).To(BeAssignableToTypeOf(map[string]any{})) // Expect 'a' to be preserved as 'b' has a conflicting type
 	})
 })
@@ -505,7 +510,7 @@ var _ = Describe("lookupValues", func() {
 
 	// --- 3. Specificity between levels ---
 
-	It("Should let GatewayConfig default overwrite GatewayClassConfig default for the same key", func() {
+	It("Should let GatewayConfig default overwrite GatewayClassConfig default, and GatewayClassConfig override beat GatewayConfig override", func() {
 		gwcb := &gwcapi.GatewayClassBlueprint{
 			ObjectMeta: metav1.ObjectMeta{Name: "bp"},
 		}
@@ -513,62 +518,33 @@ var _ = Describe("lookupValues", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: "global", Namespace: "controller-system"},
 			Spec: gwcapi.GatewayClassConfigSpec{
 				TemplateValues: gwcapi.TemplateValues{
-					Default: jsonRaw(`{"key": "gwcc-default"}`),
+					Default:  jsonRaw(`{"defaultKey": "gwcc-default"}`),
+					Override: jsonRaw(`{"overrideKey": "gwcc-override"}`),
 				},
 				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
 					Group: gatewayapi.GroupName, Kind: "GatewayClass", Name: "test-class",
 				},
 			},
 		}
+		gwc := &gwcapi.GatewayConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw-policy", Namespace: "default"},
+			Spec: gwcapi.GatewayConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Default:  jsonRaw(`{"defaultKey": "gwc-default"}`),
+					Override: jsonRaw(`{"overrideKey": "gwc-override"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: gatewayapi.GroupName, Kind: "Gateway", Name: "test-gw", Namespace: nsPtr("default"),
+				},
+			},
+		}
+		r := newFakeClient(gwcc, gwc)
+		values, err := lookupValues(ctx, r, "test-class", gwcb, "default", "test-gw")
+		Expect(err).NotTo(HaveOccurred())
 		// GatewayConfig is more specific, so its default wins
-		gwc := &gwcapi.GatewayConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: "gw-policy", Namespace: "default"},
-			Spec: gwcapi.GatewayConfigSpec{
-				TemplateValues: gwcapi.TemplateValues{
-					Default: jsonRaw(`{"key": "gwc-default"}`),
-				},
-				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
-					Group: gatewayapi.GroupName, Kind: "Gateway", Name: "test-gw", Namespace: nsPtr("default"),
-				},
-			},
-		}
-		r := newFakeClient(gwcc, gwc)
-		values, err := lookupValues(ctx, r, "test-class", gwcb, "default", "test-gw")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(values["key"]).To(Equal("gwc-default"))
-	})
-
-	It("Should let GatewayClassConfig override beat GatewayConfig override for the same key", func() {
-		gwcb := &gwcapi.GatewayClassBlueprint{
-			ObjectMeta: metav1.ObjectMeta{Name: "bp"},
-		}
-		// GatewayClassConfig override is less specific, so it should win over GatewayConfig override
-		gwcc := &gwcapi.GatewayClassConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: "global", Namespace: "controller-system"},
-			Spec: gwcapi.GatewayClassConfigSpec{
-				TemplateValues: gwcapi.TemplateValues{
-					Override: jsonRaw(`{"key": "gwcc-override"}`),
-				},
-				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
-					Group: gatewayapi.GroupName, Kind: "GatewayClass", Name: "test-class",
-				},
-			},
-		}
-		gwc := &gwcapi.GatewayConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: "gw-policy", Namespace: "default"},
-			Spec: gwcapi.GatewayConfigSpec{
-				TemplateValues: gwcapi.TemplateValues{
-					Override: jsonRaw(`{"key": "gwc-override"}`),
-				},
-				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
-					Group: gatewayapi.GroupName, Kind: "Gateway", Name: "test-gw", Namespace: nsPtr("default"),
-				},
-			},
-		}
-		r := newFakeClient(gwcc, gwc)
-		values, err := lookupValues(ctx, r, "test-class", gwcb, "default", "test-gw")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(values["key"]).To(Equal("gwcc-override"))
+		Expect(values["defaultKey"]).To(Equal("gwc-default"))
+		// GatewayClassConfig override is less specific, so it wins over GatewayConfig override
+		Expect(values["overrideKey"]).To(Equal("gwcc-override"))
 	})
 
 	It("Should let local GatewayClassConfig default beat global GatewayClassConfig default", func() {
@@ -671,7 +647,8 @@ var _ = Describe("lookupValues", func() {
 		r := newFakeClient(gwc)
 		values, err := lookupValues(ctx, r, "test-class", gwcb, "default", "test-gw")
 		Expect(err).NotTo(HaveOccurred())
-		nested := values["nested"].(map[string]any)
+		nested, ok := values["nested"].(map[string]any)
+		Expect(ok).To(BeTrue())
 		Expect(nested["bpOverride"]).To(Equal("from-bp")) // Blueprint override wins
 		Expect(nested["bpDefault"]).To(Equal("from-bp"))  // Blueprint default preserved
 		Expect(nested["gwOverride"]).To(Equal("from-gw")) // GatewayConfig override applies
@@ -802,7 +779,8 @@ var _ = Describe("lookupValues", func() {
 
 		// Nested values
 		By("Nested blueprint override wins")
-		nested := values["nested"].(map[string]any)
+		nested, ok := values["nested"].(map[string]any)
+		Expect(ok).To(BeTrue())
 		Expect(nested["someValue1"]).To(Equal("blueprint-nested-override1"))
 
 		By("Nested blueprint default is preserved")

--- a/controllers/common_test.go
+++ b/controllers/common_test.go
@@ -1,259 +1,937 @@
-// This file contain tests specifically targeted towards code in common.go
-
 package controllers
 
 import (
 	"context"
-	"time"
+	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gwcapi "github.com/tv2/bifrost-gateway-controller/apis/gateway.tv2.dk/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/yaml"
+	selfapi "github.com/tv2/bifrost-gateway-controller/pkg/api"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/dynamic"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
+	ktesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
-const commonTestGatewayClassManifest string = `
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: GatewayClass
-metadata:
-  name: common-test
-spec:
-  controllerName: "github.com/tv2/bifrost-gateway-controller"
-  parametersRef:
-    group: gateway.tv2.dk
-    kind: GatewayClassBlueprint
-    name: common-test
-`
+// ------------------------------------
+// Test Helpers
+// ------------------------------------
 
-const commonTestGatewayManifest string = `
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: Gateway
-metadata:
-  name: common-test
-  namespace: default
-spec:
-  gatewayClassName: common-test
-  listeners:
-  - name: prod-web
-    port: 80
-    protocol: HTTP
-    hostname: example.com
-`
+// jsonRaw is a helper taking a JSON string and returns a JSON struct pointer.
+func jsonRaw(s string) *apiextensionsv1.JSON {
+	return &apiextensionsv1.JSON{Raw: []byte(s)}
+}
 
-const commonTestGatewayClassBlueprintManifest string = `
-apiVersion: gateway.tv2.dk/v1alpha1
-kind: GatewayClassBlueprint
-metadata:
-  name: common-test
-spec:
-  values:
-    override:
-      someValue1: blueprint-override1
-      nested:
-        someValue1: blueprint-nested-override1
-    default:
-      someValue5: blueprint-default5
-      someValue6: blueprint-default6
-      someValue7: blueprint-default7
-      someValue8: blueprint-default8
-      nested:
-        someValue2: blueprint-nested-default2
-        someValue3: blueprint-nested-default3
+// nsPtr is a helper taking a string and returns a gatewayapi.Namespace pointer.
+func nsPtr(s string) *gatewayapi.Namespace {
+	ns := gatewayapi.Namespace(s)
+	return &ns
+}
 
-  gatewayTemplate:
-    resourceTemplates:
-      configMapTestDestination: |
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: common-test
-          namespace: {{ .Gateway.metadata.namespace }}
-        data:
-          someValue1: {{ .Values.someValue1 }}
-          someValue2: {{ .Values.someValue2 }}
-          someValue3: {{ .Values.someValue3 }}
-          someValue4: {{ .Values.someValue4 }}
-          someValue5: {{ .Values.someValue5 }}
-          someValue6: {{ .Values.someValue6 }}
-          someValue7: {{ .Values.someValue7 }}
-          someValue8: {{ .Values.someValue8 }}
-          someValue9: {{ .Values.someValue9 }}
-          someValue10: {{ .Values.someValue10 }}
-          someNestedValue1: {{ .Values.nested.someValue1 }}
-          someNestedValue2: {{ .Values.nested.someValue2 }}
-          someNestedValue3: {{ .Values.nested.someValue3 }}
-`
+// fakeControllerClient is a stub that implements the ControllerClient interface
+// by embedding a controller-runtime fake client and scheme.
+type fakeControllerClient struct {
+	cl     client.Client
+	scheme *runtime.Scheme
+}
 
-const commonTestGlobalPolicy1Manifest string = `
-apiVersion: gateway.tv2.dk/v1alpha1
-kind: GatewayClassConfig
-metadata:
-  name: common-test-global1
-  namespace: bifrost-gateway-controller-system
-spec:
-  override:
-    someValue2: global-config1-override2
-  default:
-    someValue5: global-config1-default5
-  targetRef:
-    group: gateway.networking.k8s.io
-    kind: GatewayClass
-    name: common-test
-`
+// Client() and Scheme() implement ControllerClient interface by returning the
+// embedded fake client and scheme
+func (f *fakeControllerClient) Client() client.Client   { return f.cl }
+func (f *fakeControllerClient) Scheme() *runtime.Scheme { return f.scheme }
 
-const commonTestNsPolicy1Manifest string = `
-apiVersion: gateway.tv2.dk/v1alpha1
-kind: GatewayClassConfig
-metadata:
-  name: common-test-ns1
-  namespace: default      # Note, same NS as Gateway
-spec:
-  override:
-    someValue3: global-config2-override3
-  default:
-    someValue6: global-config2-default6
-  targetRef:
-    group: gateway.networking.k8s.io
-    kind: GatewayClass
-    name: common-test
-`
+// newFakeClient creates a new fakeControllerClient with the given objects. An
+// object could be a GatewayClass, GatewayClassBlueprint, GatewayClassConfig, or
+// GatewayConfig.
+func newFakeClient(objs ...client.Object) *fakeControllerClient {
+	s := runtime.NewScheme()
+	utilruntime.Must(gwcapi.AddToScheme(s))
+	utilruntime.Must(gatewayapi.Install(s))
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+	return &fakeControllerClient{cl: cl, scheme: s}
+}
 
-const commonTestNsPolicy2Manifest string = `
-apiVersion: gateway.tv2.dk/v1alpha1
-kind: GatewayClassConfig
-metadata:
-  name: common-test-ns2
-  namespace: default      # Note, same NS as Gateway
-spec:
-  override:
-    someValue10: global-config3-override10
-  targetRef:
-    group: ""
-    kind: Namespace
-    name: default
-`
+// fakeDynControllerClient extends fakeControllerClient with a dynamic client.
+type fakeDynControllerClient struct {
+	*fakeControllerClient
+	dyn dynamic.Interface
+}
 
-const commonTestPolicy1Manifest string = `
-apiVersion: gateway.tv2.dk/v1alpha1
-kind: GatewayConfig
-metadata:
-  name: common-test-gw1
-  namespace: default
-spec:
-  override:
-    someValue2: config1-override2   # Overridden by GatewayClassConfig
-    someValue3: config1-override3   # Overridden by GatewayClassConfig
-    someValue4: config1-override4
-    nested:
-      someValue3: config1-nested-override3
-  default:
-    someValue7: config1-default7
-  targetRef:
-    group: gateway.networking.k8s.io
-    kind: Gateway
-    name: common-test
-    namespace: default
-`
+// DynamicClient() implements ControllerClient interface by returning the
+// embedded dynamic client
+func (f *fakeDynControllerClient) DynamicClient() dynamic.Interface { return f.dyn }
 
-const commonTestNsPolicy3Manifest string = `
-apiVersion: gateway.tv2.dk/v1alpha1
-kind: GatewayConfig
-metadata:
-  name: common-test-ns1
-  namespace: default
-spec:
-  default:
-    someValue9: ns-config1-default9
-  targetRef:
-    group: ""
-    kind: Namespace
-    name: default
-`
+// newFakeDynClient creates a new fakeDynControllerClient with the given objects
+// with a reactor that allows ApplyPatchType for unstructured objects.
+func newFakeDynClient(objs ...client.Object) *fakeDynControllerClient {
+	fc := newFakeClient(objs...)
+	dyn := fakedynamic.NewSimpleDynamicClient(fc.scheme)
+	// The default fake tracker requires objects to exist before Apply;
+	// intercept ApplyPatchType and return the deserialized object directly.
+	dyn.PrependReactor("patch", "*", func(action ktesting.Action) (bool, runtime.Object, error) {
+		pa := action.(ktesting.PatchAction)
+		if pa.GetPatchType() != k8stypes.ApplyPatchType {
+			return false, nil, nil
+		}
+		obj := &unstructured.Unstructured{}
+		if err := json.Unmarshal(pa.GetPatch(), &obj.Object); err != nil {
+			return true, nil, err
+		}
+		return true, obj, nil
+	})
+	return &fakeDynControllerClient{fakeControllerClient: fc, dyn: dyn}
+}
 
-var _ = Describe("Attached policies and value precedence", func() {
-
-	const (
-		timeout  = time.Second * 10
-		interval = time.Millisecond * 250
+// newFakeClientWithMapper creates a fake client with a REST mapper that knows
+// about Gateway resources. Needed by functions that resolve GVK to GVR.
+func newFakeClientWithMapper() *fakeControllerClient {
+	s := runtime.NewScheme()
+	utilruntime.Must(gwcapi.AddToScheme(s))
+	utilruntime.Must(gatewayapi.Install(s))
+	mapper := apimeta.NewDefaultRESTMapper([]schema.GroupVersion{
+		{Group: "gateway.networking.k8s.io", Version: "v1"},
+	})
+	mapper.AddSpecific(
+		schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "Gateway"},
+		schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"},
+		schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"},
+		apimeta.RESTScopeNamespace,
 	)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRESTMapper(mapper).Build()
+	return &fakeControllerClient{cl: cl, scheme: s}
+}
 
-	var (
-		gwc                 *gatewayapi.GatewayClass
-		gwcb                *gwcapi.GatewayClassBlueprint
-		gwcc1, gwcc2, gwcc3 *gwcapi.GatewayClassConfig
-		gwc1, gwc2          *gwcapi.GatewayConfig
-		ctx                 context.Context
-	)
+// ------------------------------------
+// [isOurGatewayClass] tests
+// ------------------------------------
+
+var _ = Describe("isOurGatewayClass", func() {
+	It("Should return true for matching controller (matched by ControllerName)", func() {
+		gwc := &gatewayapi.GatewayClass{
+			Spec: gatewayapi.GatewayClassSpec{ControllerName: selfapi.SelfControllerName},
+		}
+		Expect(isOurGatewayClass(gwc)).To(BeTrue())
+	})
+
+	It("Should return false for different controller (mismatched ControllerName)", func() {
+		gwc := &gatewayapi.GatewayClass{
+			Spec: gatewayapi.GatewayClassSpec{ControllerName: "example.com/other-controller"},
+		}
+		Expect(isOurGatewayClass(gwc)).To(BeFalse())
+	})
+
+	It("Should return false for empty controller (empty ControllerName)", func() {
+		gwc := &gatewayapi.GatewayClass{
+			Spec: gatewayapi.GatewayClassSpec{ControllerName: ""},
+		}
+		Expect(isOurGatewayClass(gwc)).To(BeFalse())
+	})
+})
+
+// ------------------------------------
+// [lookupGatewayClass] tests
+// ------------------------------------
+
+var _ = Describe("lookupGatewayClass", func() {
+	ctx := context.Background()
+
+	It("Should return the GatewayClass when found", func() {
+		gwc := &gatewayapi.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-class"},
+			Spec:       gatewayapi.GatewayClassSpec{ControllerName: selfapi.SelfControllerName},
+		}
+		r := newFakeClient(gwc)
+		result, err := lookupGatewayClass(ctx, r, "test-class")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Name).To(Equal("test-class"))
+	})
+
+	It("Should return an error when not found", func() {
+		r := newFakeClient()
+		_, err := lookupGatewayClass(ctx, r, "missing")
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+// ------------------------------------
+// [lookupGatewayClassBlueprint] tests
+// ------------------------------------
+
+var _ = Describe("lookupGatewayClassBlueprint", func() {
+	ctx := context.Background()
+
+	It("Should return the blueprint for a valid reference", func() {
+		gwcb := &gwcapi.GatewayClassBlueprint{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-bp"},
+		}
+		r := newFakeClient(gwcb) // preload fake client with a created blueprint
+		gwc := &gatewayapi.GatewayClass{
+			Spec: gatewayapi.GatewayClassSpec{
+				ParametersRef: &gatewayapi.ParametersReference{
+					Group: "gateway.tv2.dk",
+					Kind:  "GatewayClassBlueprint",
+					Name:  "test-bp",
+				},
+			},
+		}
+		result, err := lookupGatewayClassBlueprint(ctx, r, gwc)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Name).To(Equal("test-bp"))
+	})
+
+	It("Should error when ParametersRef is nil", func() {
+		r := newFakeClient() // no blueprints created
+		gwc := &gatewayapi.GatewayClass{
+			Spec: gatewayapi.GatewayClassSpec{},
+		}
+		_, err := lookupGatewayClassBlueprint(ctx, r, gwc)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Should error for wrong ParametersRef Kind", func() {
+		r := newFakeClient() // no blueprints created
+		gwc := &gatewayapi.GatewayClass{
+			Spec: gatewayapi.GatewayClassSpec{
+				ParametersRef: &gatewayapi.ParametersReference{
+					Group: "gateway.tv2.dk",
+					Kind:  "WrongKind",
+					Name:  "banana",
+				},
+			},
+		}
+		_, err := lookupGatewayClassBlueprint(ctx, r, gwc)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Should error for wrong ParametersRef Group", func() {
+		r := newFakeClient() // no blueprints created
+		gwc := &gatewayapi.GatewayClass{
+			Spec: gatewayapi.GatewayClassSpec{
+				ParametersRef: &gatewayapi.ParametersReference{
+					Group: "wrong.group",
+					Kind:  "GatewayClassBlueprint",
+					Name:  "banana",
+				},
+			},
+		}
+		_, err := lookupGatewayClassBlueprint(ctx, r, gwc)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Should error when blueprint is not found", func() {
+		r := newFakeClient() // no blueprints created
+		gwc := &gatewayapi.GatewayClass{
+			Spec: gatewayapi.GatewayClassSpec{
+				ParametersRef: &gatewayapi.ParametersReference{
+					Group: "gateway.tv2.dk",
+					Kind:  "GatewayClassBlueprint",
+					Name:  "banana",
+				},
+			},
+		}
+		_, err := lookupGatewayClassBlueprint(ctx, r, gwc)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+// ------------------------------------
+// [merge] tests
+// ------------------------------------
+
+var _ = Describe("merge", func() {
+	It("Should overwrite scalar values from 'b' into 'a'", func() {
+		a := map[string]any{"key": "val-a"}
+		b := map[string]any{"key": "val-b"}
+		result := merge(a, b).(map[string]any)
+		Expect(result["key"]).To(Equal("val-b")) // Expect value from b to overwrite value from a
+	})
+
+	It("Should add new keys from 'b'", func() {
+		a := map[string]any{"key1": "val1"}
+		b := map[string]any{"key2": "val2"}
+		result := merge(a, b).(map[string]any)
+		Expect(result["key1"]).To(Equal("val1")) // Expect existing key (key1) to remain unchanged
+		Expect(result["key2"]).To(Equal("val2")) // Expect new key (key2) from b to be added
+	})
+
+	It("Should merge nested maps", func() {
+		a := map[string]any{"metadata": map[string]any{"onlyInA": "1", "shared": "2"}}
+		b := map[string]any{"metadata": map[string]any{"shared": "3", "onlyInB": "4"}}
+		result := merge(a, b).(map[string]any)
+		metadata := result["metadata"].(map[string]any)
+		Expect(metadata["onlyInA"]).To(Equal("1")) // Expect existing key to remain unchanged
+		Expect(metadata["shared"]).To(Equal("3"))  // Expect shared key to be overwritten by b
+		Expect(metadata["onlyInB"]).To(Equal("4")) // Expect new key from b to be added
+	})
+
+	It("Should preserve 'a' on type conflict (map vs scalar)", func() {
+		a := map[string]any{"key": map[string]any{"nested": "value"}}
+		b := map[string]any{"key": "scalar"}
+		result := merge(a, b).(map[string]any)
+		Expect(result["key"]).To(BeAssignableToTypeOf(map[string]any{})) // Expect 'a' to be preserved as 'b' has a conflicting type
+	})
+})
+
+// ------------------------------------
+// [lookupValues] tests
+//
+// Specificity (from least specific to most specific):
+//  1. Blueprint                 (Blueprint)    - cluster-wide baseline values, applies to all GatewayClasses (least specific)
+//  2. Global GatewayClassConfig (GatewayClass) - lives in controller namespace, targets a specific GatewayClass across all namespaces
+//  3. Local GatewayClassConfig  (Namespace)    - lives in gateway namespace, targets all GatewayClasses in that namespace
+//  4. Local GatewayClassConfig  (GatewayClass) - lives in gateway namespace, targets a specific GatewayClass in that namespace
+//  5. GatewayConfig             (Namespace)    - lives in gateway namespace, targets all Gateways in that namespace
+//  6. GatewayConfig             (Gateway)      - lives in gateway namespace, targets a specific Gateway by name (most specific)
+//
+// The default/override distinction flips who wins:
+// - Defaults: more specific wins (Gateway > Namespace > GatewayClass > Blueprint)
+// - Overrides: less specific wins (Blueprint > GatewayClass > Namespace > Gateway) — lets platform operators enforce constraints
+//
+// Tests are ordered by topic:
+//  1. Individual policy levels (blueprint, global GatewayClassConfig, local GatewayClassConfig, GatewayConfig)
+//  2. Filtering (wrong targetRef)
+//  3. Specificity between policy levels
+//  4. Conflict resolution (multiple policies at same level)
+//  5. Nested value merging
+//  6. Combined policy levels
+//
+// See https://gateway-api.sigs.k8s.io/references/policy-attachment/#hierarchy
+// See https://gateway-api.sigs.k8s.io/geps/gep-713/#established-and-challenger-policy-specs
+var _ = Describe("lookupValues", func() {
+	ctx := context.Background()
 
 	BeforeEach(func() {
-		gwc = &gatewayapi.GatewayClass{}
-		gwcb = &gwcapi.GatewayClassBlueprint{}
-		gwcc1 = &gwcapi.GatewayClassConfig{}
-		gwcc2 = &gwcapi.GatewayClassConfig{}
-		gwcc3 = &gwcapi.GatewayClassConfig{}
-		gwc1 = &gwcapi.GatewayConfig{}
-		gwc2 = &gwcapi.GatewayConfig{}
-		ctx = context.Background()
-		Expect(yaml.Unmarshal([]byte(commonTestGatewayClassManifest), gwc)).To(Succeed())
-		Expect(k8sClient.Create(ctx, gwc)).Should(Succeed())
-		Expect(yaml.Unmarshal([]byte(commonTestGatewayClassBlueprintManifest), gwcb)).To(Succeed())
-		Expect(k8sClient.Create(ctx, gwcb)).Should(Succeed())
-		Expect(yaml.Unmarshal([]byte(commonTestGlobalPolicy1Manifest), gwcc1)).To(Succeed())
-		Expect(k8sClient.Create(ctx, gwcc1)).Should(Succeed())
-		Expect(yaml.Unmarshal([]byte(commonTestNsPolicy1Manifest), gwcc2)).To(Succeed())
-		Expect(k8sClient.Create(ctx, gwcc2)).Should(Succeed())
-		Expect(yaml.Unmarshal([]byte(commonTestNsPolicy2Manifest), gwcc3)).To(Succeed())
-		Expect(k8sClient.Create(ctx, gwcc3)).Should(Succeed())
-		Expect(yaml.Unmarshal([]byte(commonTestPolicy1Manifest), gwc1)).To(Succeed())
-		Expect(k8sClient.Create(ctx, gwc1)).Should(Succeed())
-		Expect(yaml.Unmarshal([]byte(commonTestNsPolicy3Manifest), gwc2)).To(Succeed())
-		Expect(k8sClient.Create(ctx, gwc2)).Should(Succeed())
+		ControllerNamespace = "controller-system"
 	})
 
-	AfterEach(func() {
-		Expect(k8sClient.Delete(ctx, gwc)).Should(Succeed())
-		Expect(k8sClient.Delete(ctx, gwcb)).Should(Succeed())
-		Expect(k8sClient.Delete(ctx, gwcc1)).Should(Succeed())
-		Expect(k8sClient.Delete(ctx, gwcc2)).Should(Succeed())
-		Expect(k8sClient.Delete(ctx, gwcc3)).Should(Succeed())
-		Expect(k8sClient.Delete(ctx, gwc1)).Should(Succeed())
-		Expect(k8sClient.Delete(ctx, gwc2)).Should(Succeed())
+	// --- 1. Individual policy levels ---
+
+	It("Should return blueprint defaults when no policies exist", func() {
+		gwcb := &gwcapi.GatewayClassBlueprint{
+			ObjectMeta: metav1.ObjectMeta{Name: "bp"},
+			Spec: gwcapi.GatewayClassBlueprintSpec{
+				Values: gwcapi.TemplateValues{
+					Default: jsonRaw(`{"key": "bp-default"}`),
+				},
+			},
+		}
+		r := newFakeClient() // no policies
+		values, err := lookupValues(ctx, r, "test-class", gwcb, "default", "test-gw")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(values["key"]).To(Equal("bp-default"))
 	})
 
-	When("Reconciling a parent Gateway", func() {
-		var gw *gatewayapi.Gateway
-		BeforeEach(func() {
-			gw = &gatewayapi.Gateway{}
-			Expect(yaml.Unmarshal([]byte(commonTestGatewayManifest), gw)).To(Succeed())
-			Expect(k8sClient.Create(ctx, gw)).Should(Succeed())
-		})
+	It("Should let blueprint override always win", func() {
+		// GatewayClassBlueprint override should always win
+		gwcb := &gwcapi.GatewayClassBlueprint{
+			ObjectMeta: metav1.ObjectMeta{Name: "bp"},
+			Spec: gwcapi.GatewayClassBlueprintSpec{
+				Values: gwcapi.TemplateValues{
+					Override: jsonRaw(`{"key": "bp-override"}`),
+				},
+			},
+		}
+		// Competing GatewayClassConfig override for the same key and should be ignored
+		gwcc := &gwcapi.GatewayClassConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "global", Namespace: "controller-system"},
+			Spec: gwcapi.GatewayClassConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Override: jsonRaw(`{"key": "gwcc-override"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: gatewayapi.GroupName, Kind: "GatewayClass", Name: "test-class",
+				},
+			},
+		}
+		r := newFakeClient(gwcc) // preload fake client with a created GatewayClassConfig
+		values, err := lookupValues(ctx, r, "test-class", gwcb, "default", "test-gw")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(values["key"]).To(Equal("bp-override"))
+	})
 
-		It("Should use values correctly", func() {
+	It("Should let global GatewayClassConfig default overwrite blueprint defaults", func() {
+		// GatewayClassBlueprint default should be overwritten by
+		// GatewayClassConfig default as it is more specific
+		gwcb := &gwcapi.GatewayClassBlueprint{
+			ObjectMeta: metav1.ObjectMeta{Name: "bp"},
+			Spec: gwcapi.GatewayClassBlueprintSpec{
+				Values: gwcapi.TemplateValues{
+					Default: jsonRaw(`{"key": "bp-default"}`),
+				},
+			},
+		}
+		// Global GatewayClassConfig in controller namespace targeting the
+		// GatewayClass should apply to all Gateways of that class, so it should
+		// overwrite the blueprint default
+		gwcc := &gwcapi.GatewayClassConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "global", Namespace: "controller-system"},
+			Spec: gwcapi.GatewayClassConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Default: jsonRaw(`{"key": "gwcc-default"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: gatewayapi.GroupName, Kind: "GatewayClass", Name: "test-class",
+				},
+			},
+		}
+		r := newFakeClient(gwcc) // preload fake client with a created GatewayClassConfig
+		values, err := lookupValues(ctx, r, "test-class", gwcb, "default", "test-gw")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(values["key"]).To(Equal("gwcc-default"))
+	})
 
-			cm := corev1.ConfigMap{}
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{Name: "common-test", Namespace: "default"}, &cm)
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
+	It("Should let namespace-scoped GatewayClassConfig default apply to gateways in that namespace", func() {
+		gwcb := &gwcapi.GatewayClassBlueprint{
+			ObjectMeta: metav1.ObjectMeta{Name: "bp"},
+		}
+		// GatewayClassConfig in Gateway namespace, targeting the Namespace
+		gwcc := &gwcapi.GatewayClassConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "ns-policy", Namespace: "default"},
+			Spec: gwcapi.GatewayClassConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Default: jsonRaw(`{"nsKey": "from-gwcc-ns"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{ // targets Namespace instead of a specific Gateway
+					Group: "", Kind: "Namespace", Name: "default",
+				},
+			},
+		}
+		r := newFakeClient(gwcc) // preload fake client with a created GatewayClassConfig
+		values, err := lookupValues(ctx, r, "test-class", gwcb, "default", "test-gw")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(values["nsKey"]).To(Equal("from-gwcc-ns"))
+	})
 
-			// https://gateway-api.sigs.k8s.io/references/policy-attachment/#hierarchy
-			By("Setting the content of the destination configmap according to GEP-713")
-			Expect(cm.Data["someValue1"]).To(Equal("blueprint-override1"))
-			Expect(cm.Data["someValue2"]).To(Equal("global-config1-override2"))
-			Expect(cm.Data["someValue3"]).To(Equal("global-config2-override3"))
-			Expect(cm.Data["someValue4"]).To(Equal("config1-override4"))
-			Expect(cm.Data["someValue5"]).To(Equal("global-config1-default5"))
-			Expect(cm.Data["someValue6"]).To(Equal("global-config2-default6"))
-			Expect(cm.Data["someValue7"]).To(Equal("config1-default7"))
-			Expect(cm.Data["someValue8"]).To(Equal("blueprint-default8"))
-			Expect(cm.Data["someValue9"]).To(Equal("ns-config1-default9"))
-			Expect(cm.Data["someValue10"]).To(Equal("global-config3-override10"))
-			Expect(cm.Data["someNestedValue1"]).To(Equal("blueprint-nested-override1"))
-			Expect(cm.Data["someNestedValue2"]).To(Equal("blueprint-nested-default2"))
-			Expect(cm.Data["someNestedValue3"]).To(Equal("config1-nested-override3"))
-		})
+	It("Should apply local GatewayClassConfig targeting GatewayClass", func() {
+		gwcb := &gwcapi.GatewayClassBlueprint{
+			ObjectMeta: metav1.ObjectMeta{Name: "bp"},
+		}
+		// GatewayClassConfig in Gateway namespace, targeting the GatewayClass
+		gwcc := &gwcapi.GatewayClassConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "local-gwc-policy", Namespace: "default"},
+			Spec: gwcapi.GatewayClassConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Default: jsonRaw(`{"localKey": "from-local-gwcc"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: gatewayapi.GroupName, Kind: "GatewayClass", Name: "test-class",
+				},
+			},
+		}
+		r := newFakeClient(gwcc)
+		values, err := lookupValues(ctx, r, "test-class", gwcb, "default", "test-gw")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(values["localKey"]).To(Equal("from-local-gwcc"))
+	})
+
+	It("Should apply GatewayConfig targeting a specific Gateway", func() {
+		gwcb := &gwcapi.GatewayClassBlueprint{
+			ObjectMeta: metav1.ObjectMeta{Name: "bp"},
+		}
+		gwc := &gwcapi.GatewayConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw-policy", Namespace: "default"},
+			Spec: gwcapi.GatewayConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Default: jsonRaw(`{"gwKey": "from-gw-config"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: gatewayapi.GroupName, Kind: "Gateway", Name: "test-gw", Namespace: nsPtr("default"),
+				},
+			},
+		}
+		r := newFakeClient(gwc)
+		values, err := lookupValues(ctx, r, "test-class", gwcb, "default", "test-gw")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(values["gwKey"]).To(Equal("from-gw-config"))
+	})
+
+	It("Should apply namespace-targeted GatewayConfig", func() {
+		gwcb := &gwcapi.GatewayClassBlueprint{
+			ObjectMeta: metav1.ObjectMeta{Name: "bp"},
+		}
+		// Targets Namespace instead of a specific Gateway
+		gwc := &gwcapi.GatewayConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "ns-policy", Namespace: "default"},
+			Spec: gwcapi.GatewayConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Default: jsonRaw(`{"nsKey": "from-ns"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Kind: "Namespace", Name: "default",
+				},
+			},
+		}
+		r := newFakeClient(gwc)
+		values, err := lookupValues(ctx, r, "test-class", gwcb, "default", "test-gw")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(values["nsKey"]).To(Equal("from-ns"))
+	})
+
+	// --- 2. Filtering ---
+
+	It("Should not apply GatewayConfig targeting a different Gateway", func() {
+		gwcb := &gwcapi.GatewayClassBlueprint{
+			ObjectMeta: metav1.ObjectMeta{Name: "bp"},
+		}
+		// Targets "other-gw", not our "test-gw"
+		gwc := &gwcapi.GatewayConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw-policy", Namespace: "default"},
+			Spec: gwcapi.GatewayConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Default: jsonRaw(`{"gwKey": "should-not-appear"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: gatewayapi.GroupName, Kind: "Gateway", Name: "other-gw", Namespace: nsPtr("default"),
+				},
+			},
+		}
+		r := newFakeClient(gwc)
+		values, err := lookupValues(ctx, r, "test-class", gwcb, "default", "test-gw")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(values).NotTo(HaveKey("gwKey"))
+	})
+
+	// --- 3. Specificity between levels ---
+
+	It("Should let GatewayConfig default overwrite GatewayClassConfig default for the same key", func() {
+		gwcb := &gwcapi.GatewayClassBlueprint{
+			ObjectMeta: metav1.ObjectMeta{Name: "bp"},
+		}
+		gwcc := &gwcapi.GatewayClassConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "global", Namespace: "controller-system"},
+			Spec: gwcapi.GatewayClassConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Default: jsonRaw(`{"key": "gwcc-default"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: gatewayapi.GroupName, Kind: "GatewayClass", Name: "test-class",
+				},
+			},
+		}
+		// GatewayConfig is more specific, so its default wins
+		gwc := &gwcapi.GatewayConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw-policy", Namespace: "default"},
+			Spec: gwcapi.GatewayConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Default: jsonRaw(`{"key": "gwc-default"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: gatewayapi.GroupName, Kind: "Gateway", Name: "test-gw", Namespace: nsPtr("default"),
+				},
+			},
+		}
+		r := newFakeClient(gwcc, gwc)
+		values, err := lookupValues(ctx, r, "test-class", gwcb, "default", "test-gw")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(values["key"]).To(Equal("gwc-default"))
+	})
+
+	It("Should let GatewayClassConfig override beat GatewayConfig override for the same key", func() {
+		gwcb := &gwcapi.GatewayClassBlueprint{
+			ObjectMeta: metav1.ObjectMeta{Name: "bp"},
+		}
+		// GatewayClassConfig override is less specific, so it should win over GatewayConfig override
+		gwcc := &gwcapi.GatewayClassConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "global", Namespace: "controller-system"},
+			Spec: gwcapi.GatewayClassConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Override: jsonRaw(`{"key": "gwcc-override"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: gatewayapi.GroupName, Kind: "GatewayClass", Name: "test-class",
+				},
+			},
+		}
+		gwc := &gwcapi.GatewayConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw-policy", Namespace: "default"},
+			Spec: gwcapi.GatewayConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Override: jsonRaw(`{"key": "gwc-override"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: gatewayapi.GroupName, Kind: "Gateway", Name: "test-gw", Namespace: nsPtr("default"),
+				},
+			},
+		}
+		r := newFakeClient(gwcc, gwc)
+		values, err := lookupValues(ctx, r, "test-class", gwcb, "default", "test-gw")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(values["key"]).To(Equal("gwcc-override"))
+	})
+
+	It("Should let local GatewayClassConfig default beat global GatewayClassConfig default", func() {
+		gwcb := &gwcapi.GatewayClassBlueprint{
+			ObjectMeta: metav1.ObjectMeta{Name: "bp"},
+		}
+		// Global GatewayClassConfig in controller namespace
+		globalGwcc := &gwcapi.GatewayClassConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "global-policy", Namespace: "controller-system"},
+			Spec: gwcapi.GatewayClassConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Default: jsonRaw(`{"key": "global-default"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: gatewayapi.GroupName, Kind: "GatewayClass", Name: "test-class",
+				},
+			},
+		}
+		// Local GatewayClassConfig in Gateway namespace should overwrite global
+		// GatewayClassConfig default as it is more specific
+		localGwcc := &gwcapi.GatewayClassConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "local-policy", Namespace: "default"},
+			Spec: gwcapi.GatewayClassConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Default: jsonRaw(`{"key": "local-default"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: "", Kind: "Namespace", Name: "default",
+				},
+			},
+		}
+		r := newFakeClient(globalGwcc, localGwcc)
+		values, err := lookupValues(ctx, r, "test-class", gwcb, "default", "test-gw")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(values["key"]).To(Equal("local-default"))
+	})
+
+	// --- 4. Conflict resolution ---
+
+	It("Should resolve same-level conflicts by policy name ordering", func() {
+		gwcb := &gwcapi.GatewayClassBlueprint{
+			ObjectMeta: metav1.ObjectMeta{Name: "bp"},
+		}
+		// Two GatewayClassConfigs at the same level (both global, targeting GatewayClass)
+		gwccFirst := &gwcapi.GatewayClassConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "aaa-first", Namespace: "controller-system"},
+			Spec: gwcapi.GatewayClassConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Default:  jsonRaw(`{"defKey": "first-default"}`),  // Defaults: alphabetically-last policy name wins, so this loses
+					Override: jsonRaw(`{"ovrKey": "first-override"}`), // Overrides: alphabetically-first policy name wins, so this wins
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: gatewayapi.GroupName, Kind: "GatewayClass", Name: "test-class",
+				},
+			},
+		}
+		gwccSecond := &gwcapi.GatewayClassConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "zzz-second", Namespace: "controller-system"},
+			Spec: gwcapi.GatewayClassConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Default:  jsonRaw(`{"defKey": "second-default"}`),  // Defaults: alphabetically-last policy name wins, so this wins
+					Override: jsonRaw(`{"ovrKey": "second-override"}`), // Overrides: alphabetically-first policy name wins, so this loses
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: gatewayapi.GroupName, Kind: "GatewayClass", Name: "test-class",
+				},
+			},
+		}
+		r := newFakeClient(gwccFirst, gwccSecond)
+		values, err := lookupValues(ctx, r, "test-class", gwcb, "default", "test-gw")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(values["defKey"]).To(Equal("second-default")) // Alphabetically-last policy name wins for defaults
+		Expect(values["ovrKey"]).To(Equal("first-override")) // Alphabetically-first policy name wins for overrides
+	})
+
+	// --- 5. Nested values ---
+
+	It("Should merge nested values with correct precedence", func() {
+		gwcb := &gwcapi.GatewayClassBlueprint{
+			ObjectMeta: metav1.ObjectMeta{Name: "bp"},
+			Spec: gwcapi.GatewayClassBlueprintSpec{
+				Values: gwcapi.TemplateValues{
+					Override: jsonRaw(`{"nested": {"bpOverride": "from-bp"}}`),
+					Default:  jsonRaw(`{"nested": {"bpDefault": "from-bp", "shared": "bp"}}`),
+				},
+			},
+		}
+		gwc := &gwcapi.GatewayConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "gw-policy", Namespace: "default"},
+			Spec: gwcapi.GatewayConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Override: jsonRaw(`{"nested": {"gwOverride": "from-gw", "bpOverride": "from-gw"}}`),
+					Default:  jsonRaw(`{"nested": {"shared": "gw"}}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: gatewayapi.GroupName, Kind: "Gateway", Name: "test-gw", Namespace: nsPtr("default"),
+				},
+			},
+		}
+		r := newFakeClient(gwc)
+		values, err := lookupValues(ctx, r, "test-class", gwcb, "default", "test-gw")
+		Expect(err).NotTo(HaveOccurred())
+		nested := values["nested"].(map[string]any)
+		Expect(nested["bpOverride"]).To(Equal("from-bp")) // Blueprint override wins
+		Expect(nested["bpDefault"]).To(Equal("from-bp"))  // Blueprint default preserved
+		Expect(nested["gwOverride"]).To(Equal("from-gw")) // GatewayConfig override applies
+		Expect(nested["shared"]).To(Equal("gw"))          // GatewayConfig default overwrites blueprint default
+	})
+
+	// --- 6. Combined policy levels ---
+
+	It("Should apply all policy levels with correct precedence (GEP-713)", func() {
+		ControllerNamespace = "bifrost-gateway-controller-system"
+		gwcb := &gwcapi.GatewayClassBlueprint{
+			ObjectMeta: metav1.ObjectMeta{Name: "common-test"},
+			Spec: gwcapi.GatewayClassBlueprintSpec{
+				Values: gwcapi.TemplateValues{
+					Override: jsonRaw(`{"someValue1": "blueprint-override1", "nested": {"someValue1": "blueprint-nested-override1"}}`),
+					Default:  jsonRaw(`{"someValue5": "blueprint-default5", "someValue6": "blueprint-default6", "someValue7": "blueprint-default7", "someValue8": "blueprint-default8", "nested": {"someValue2": "blueprint-nested-default2", "someValue3": "blueprint-nested-default3"}}`),
+				},
+			},
+		}
+
+		// Global GatewayClassConfig in controller namespace, targeting GatewayClass
+		gwccGlobal := &gwcapi.GatewayClassConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "common-test-global1", Namespace: "bifrost-gateway-controller-system"},
+			Spec: gwcapi.GatewayClassConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Override: jsonRaw(`{"someValue2": "global-config1-override2"}`),
+					Default:  jsonRaw(`{"someValue5": "global-config1-default5"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: gatewayapi.GroupName, Kind: "GatewayClass", Name: "common-test",
+				},
+			},
+		}
+
+		// Namespace GatewayClassConfig targeting GatewayClass (same namespace as Gateway)
+		gwccNs1 := &gwcapi.GatewayClassConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "common-test-ns1", Namespace: "default"},
+			Spec: gwcapi.GatewayClassConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Override: jsonRaw(`{"someValue3": "global-config2-override3"}`),
+					Default:  jsonRaw(`{"someValue6": "global-config2-default6"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: gatewayapi.GroupName, Kind: "GatewayClass", Name: "common-test",
+				},
+			},
+		}
+
+		// Namespace GatewayClassConfig targeting Namespace
+		gwccNs2 := &gwcapi.GatewayClassConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "common-test-ns2", Namespace: "default"},
+			Spec: gwcapi.GatewayClassConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Override: jsonRaw(`{"someValue10": "global-config3-override10"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: "", Kind: "Namespace", Name: "default",
+				},
+			},
+		}
+
+		// GatewayConfig targeting Gateway (with nested override)
+		gwcGw := &gwcapi.GatewayConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "common-test-gw1", Namespace: "default"},
+			Spec: gwcapi.GatewayConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Override: jsonRaw(`{"someValue2": "config1-override2", "someValue3": "config1-override3", "someValue4": "config1-override4", "nested": {"someValue3": "config1-nested-override3"}}`),
+					Default:  jsonRaw(`{"someValue7": "config1-default7"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: gatewayapi.GroupName, Kind: "Gateway", Name: "common-test", Namespace: nsPtr("default"),
+				},
+			},
+		}
+
+		// GatewayConfig targeting Namespace
+		gwcNs := &gwcapi.GatewayConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "common-test-ns1", Namespace: "default"},
+			Spec: gwcapi.GatewayConfigSpec{
+				TemplateValues: gwcapi.TemplateValues{
+					Default: jsonRaw(`{"someValue9": "ns-config1-default9"}`),
+				},
+				TargetRef: gatewayv1a2.NamespacedPolicyTargetReference{
+					Group: "", Kind: "Namespace", Name: "default",
+				},
+			},
+		}
+
+		r := newFakeClient(gwccGlobal, gwccNs1, gwccNs2, gwcGw, gwcNs)
+		values, err := lookupValues(ctx, r, "common-test", gwcb, "default", "common-test")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Blueprint override wins over everything
+		By("Blueprint override has highest precedence")
+		Expect(values["someValue1"]).To(Equal("blueprint-override1"))
+
+		// GatewayClassConfig override beats GatewayConfig override
+		By("Global GatewayClassConfig override beats GatewayConfig override")
+		Expect(values["someValue2"]).To(Equal("global-config1-override2"))
+
+		By("Namespace GatewayClassConfig override beats GatewayConfig override")
+		Expect(values["someValue3"]).To(Equal("global-config2-override3"))
+
+		// GatewayConfig override when no higher-level override
+		By("GatewayConfig override applies when no higher override exists")
+		Expect(values["someValue4"]).To(Equal("config1-override4"))
+
+		// GatewayClassConfig default overwrites blueprint default
+		By("GatewayClassConfig default overwrites blueprint default")
+		Expect(values["someValue5"]).To(Equal("global-config1-default5"))
+		Expect(values["someValue6"]).To(Equal("global-config2-default6"))
+
+		// GatewayConfig default overwrites blueprint default
+		By("GatewayConfig default overwrites blueprint default")
+		Expect(values["someValue7"]).To(Equal("config1-default7"))
+
+		// Blueprint default when nothing overrides it
+		By("Blueprint default is used when no policy overrides it")
+		Expect(values["someValue8"]).To(Equal("blueprint-default8"))
+
+		// Namespace-targeted GatewayConfig default
+		By("Namespace-targeted GatewayConfig default applies")
+		Expect(values["someValue9"]).To(Equal("ns-config1-default9"))
+
+		// Namespace-targeted GatewayClassConfig override
+		By("Namespace-targeted GatewayClassConfig override applies")
+		Expect(values["someValue10"]).To(Equal("global-config3-override10"))
+
+		// Nested values
+		By("Nested blueprint override wins")
+		nested := values["nested"].(map[string]any)
+		Expect(nested["someValue1"]).To(Equal("blueprint-nested-override1"))
+
+		By("Nested blueprint default is preserved")
+		Expect(nested["someValue2"]).To(Equal("blueprint-nested-default2"))
+
+		By("Nested GatewayConfig override applies")
+		Expect(nested["someValue3"]).To(Equal("config1-nested-override3"))
+	})
+})
+
+// ------------------------------------
+// [lookupGateway] tests
+// ------------------------------------
+
+var _ = Describe("lookupGateway", func() {
+	ctx := context.Background()
+
+	It("Should return the Gateway when found", func() {
+		gw := &gatewayapi.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-gw", Namespace: "default"},
+			Spec: gatewayapi.GatewaySpec{
+				GatewayClassName: "test-class",
+			},
+		}
+		r := newFakeClient(gw)
+		result, err := lookupGateway(ctx, r, "test-gw", "default")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Name).To(Equal("test-gw"))
+		Expect(result.Namespace).To(Equal("default"))
+	})
+
+	It("Should return an error when not found", func() {
+		r := newFakeClient()
+		_, err := lookupGateway(ctx, r, "missing", "default")
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+// ------------------------------------
+// [unstructuredToGVR] tests
+// ------------------------------------
+
+var _ = Describe("unstructuredToGVR", func() {
+	It("Should return GVR and namespaced=true for a known namespaced resource", func() {
+		r := newFakeClientWithMapper()
+		u := &unstructured.Unstructured{}
+		u.SetAPIVersion("gateway.networking.k8s.io/v1")
+		u.SetKind("Gateway")
+
+		gotGVR, isNamespaced, err := unstructuredToGVR(r, u)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gotGVR.Resource).To(Equal("gateways"))
+		Expect(isNamespaced).To(BeTrue())
+	})
+
+	It("Should return error for invalid apiVersion", func() {
+		r := newFakeClient()
+		u := &unstructured.Unstructured{}
+		u.SetAPIVersion("not/a/valid/version")
+		u.SetKind("Something")
+		_, _, err := unstructuredToGVR(r, u)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Should return error for unknown kind", func() {
+		r := newFakeClient()
+		u := &unstructured.Unstructured{}
+		u.SetAPIVersion("v1")
+		u.SetKind("DoesNotExist")
+		_, _, err := unstructuredToGVR(r, u)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+// ------------------------------------
+// [patchUnstructured] tests
+// ------------------------------------
+
+var _ = Describe("patchUnstructured", func() {
+	ctx := context.Background()
+
+	It("Should patch a namespaced resource", func() {
+		r := newFakeDynClient()
+		us := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "gateway.networking.k8s.io/v1",
+				"kind":       "Gateway",
+				"metadata":   map[string]any{"name": "test-gw"},
+			},
+		}
+		gvr := &schema.GroupVersionResource{
+			Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways",
+		}
+		ns := "default"
+		err := patchUnstructured(ctx, r, us, gvr, &ns)
+		Expect(err).NotTo(HaveOccurred()) // TODO: could be great if we return the patched object and assert on it to verify the patch was applied correctly
+	})
+
+	It("Should patch a cluster-scoped resource", func() {
+		r := newFakeDynClient()
+		us := &unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": "gateway.networking.k8s.io/v1",
+				"kind":       "GatewayClass",
+				"metadata":   map[string]any{"name": "test-class"},
+			},
+		}
+		gvr := &schema.GroupVersionResource{
+			Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gatewayclasses",
+		}
+		err := patchUnstructured(ctx, r, us, gvr, nil)
+		Expect(err).NotTo(HaveOccurred()) // TODO: could be great if we return the patched object and assert on it to verify the patch was applied correctly
+	})
+})
+
+// ------------------------------------
+// [PtrTo] tests
+// ------------------------------------
+
+var _ = Describe("PtrTo", func() {
+	It("Should return pointer to string", func() {
+		Expect(*PtrTo("hello")).To(Equal("hello"))
+	})
+
+	It("Should return pointer to int", func() {
+		Expect(*PtrTo(42)).To(Equal(42))
+	})
+
+	It("Should return pointer to bool", func() {
+		Expect(*PtrTo(true)).To(BeTrue())
 	})
 })

--- a/controllers/gateway_controller_test.go
+++ b/controllers/gateway_controller_test.go
@@ -268,7 +268,7 @@ var _ = Describe("combineHostnames", func() {
 	}
 
 	// rtWith is a helper to create an HTTPRoute with the given hostnames
-	rtWith := func(ns string, hostnames ...string) *gatewayapi.HTTPRoute {
+	rtWith := func(ns string, hostnames ...string) *gatewayapi.HTTPRoute { //nolint:unparam // ns is always "default" in tests but kept for clarity
 		rt := &gatewayapi.HTTPRoute{}
 		rt.Namespace = ns
 		for _, h := range hostnames {
@@ -567,7 +567,7 @@ var _ = Describe("Gateway controller", func() {
 			Expect(setGatewayStatus(gwChildNN, &metav1.Condition{
 				Type:   string(gatewayapi.GatewayConditionReady),
 				Status: metav1.ConditionFalse,
-				//nolint:staticcheck
+				//nolint:staticcheck // GatewayReasonReady is deprecated but still used by the upstream API
 				Reason: string(gatewayapi.GatewayReasonReady)}, nil)).Should(Succeed())
 			time.Sleep(5 * time.Second)
 
@@ -598,7 +598,7 @@ var _ = Describe("Gateway controller", func() {
 			Expect(setGatewayStatus(gwChildNN, &metav1.Condition{
 				Type:   string(gatewayapi.GatewayConditionReady),
 				Status: metav1.ConditionTrue,
-				//nolint:staticcheck
+				//nolint:staticcheck // GatewayReasonReady is deprecated but still used by the upstream API
 				Reason: string(gatewayapi.GatewayReasonReady)},
 				&gatewayapi.GatewayStatusAddress{Type: &addrType, Value: "4.5.6.7"})).Should(Succeed())
 

--- a/controllers/gateway_controller_test.go
+++ b/controllers/gateway_controller_test.go
@@ -34,6 +34,7 @@ package controllers
 import (
 	"context"
 	"regexp"
+	"sort"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -43,360 +44,16 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/yaml"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1"
 
 	"sigs.k8s.io/gateway-api/conformance/utils/kubernetes"
 )
 
-const gatewayClassManifest string = `
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: GatewayClass
-metadata:
-  name: default
-spec:
-  controllerName: "github.com/tv2/bifrost-gateway-controller"
-  parametersRef:
-    group: gateway.tv2.dk
-    kind: GatewayClassBlueprint
-    name: default-gateway-class`
+// ------------------------------------
+// Test Helpers
+// ------------------------------------
 
-const gatewayManifest string = `
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: Gateway
-metadata:
-  name: foo-gateway
-  namespace: default
-spec:
-  gatewayClassName: default
-  listeners:
-  - name: prod-web
-    port: 80
-    protocol: HTTP
-    hostname: example.com
-`
-
-const gatewayClassBlueprintManifest string = `
-apiVersion: gateway.tv2.dk/v1alpha1
-kind: GatewayClassBlueprint
-metadata:
-  name: default-gateway-class
-spec:
-  values:
-    default:
-      configmap2SuffixData:
-      - one
-      - two
-      - three
-  gatewayTemplate:
-    status:
-      template: |
-        addresses:
-          {{ toYaml (index .Resources.childGateway 0).status.addresses | nindent 2}}
-    resourceTemplates:
-      childGateway: |
-        apiVersion: gateway.networking.k8s.io/v1beta1
-        kind: Gateway
-        metadata:
-          name: {{ .Gateway.metadata.name }}-istio
-          namespace: {{ .Gateway.metadata.namespace }}
-          annotations:
-            networking.istio.io/service-type: ClusterIP
-        spec:
-          gatewayClassName: istio
-          listeners:
-            {{- toYaml .Gateway.spec.listeners | nindent 6 }}
-      # The following three configmaps tests referencing between resources
-      configMapTestSource: |
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: source-configmap
-          namespace: {{ .Gateway.metadata.namespace }}
-        data:
-          valueToRead1: Hello
-          valueToRead2: World
-      configMapTestIntermediate1: |
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: intermediate1-configmap
-          namespace: {{ .Gateway.metadata.namespace }}
-        data:
-          valueIntermediate: {{ (index .Resources.configMapTestSource 0).data.valueToRead1 }}
-      configMapTestIntermediate2: |
-        {{ range $idx,$suffix := .Values.configmap2SuffixData }}
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: intermediate2-configmap-{{ $idx }}
-          namespace: {{ $.Gateway.metadata.namespace }}
-        data:
-          valueIntermediate: {{ (index $.Resources.configMapTestSource 0).data.valueToRead1 }}-{{ $suffix }}
-        ---
-        {{ end }}
-      # Use references to multiple resources coupled with template pipeline and functions
-      configMapTestDestination: |
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: dst-configmap
-          namespace: {{ .Gateway.metadata.namespace }}
-        data:
-          valueRead: {{ printf "%s, %s" (index .Resources.configMapTestIntermediate1 0).data.valueIntermediate (index .Resources.configMapTestSource 0).data.valueToRead2 | upper }}
-          valueRead2: {{ printf "Testing, one two %s" (index .Resources.configMapTestIntermediate2 2).data.valueIntermediate | upper }}
-  httpRouteTemplate:
-    resourceTemplates:
-      shadowHttproute: |
-        apiVersion: gateway.networking.k8s.io/v1beta1
-        kind: HTTPRoute
-        metadata:
-          name: {{ .HTTPRoute.metadata.name }}-istio
-          namespace: {{ .HTTPRoute.metadata.namespace }}
-        spec:
-          parentRefs:
-          {{ range .HTTPRoute.spec.parentRefs }}
-          - kind: {{ .kind }}
-            name: {{ .name }}-istio
-            namespace: {{ .namespace }}
-          {{ end }}
-          rules:
-          {{ toYaml .HTTPRoute.spec.rules | nindent 4 }}`
-
-// Blueprint that creates resources that never become ready
-const gatewayClassBlueprintManifestNonReady string = `
-apiVersion: gateway.tv2.dk/v1alpha1
-kind: GatewayClassBlueprint
-metadata:
-  name: default-gateway-class
-spec:
-  values: null
-  gatewayTemplate:
-    resourceTemplates:
-      configMapTestSource: |
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: source-configmap
-          namespace: {{ .Gateway.metadata.namespace }}
-        data:
-          valueToRead1: Hello
-          valueToRead2: World
-      configMapTestIntermediate1: |
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: intermediate1-configmap
-          namespace: {{ .Gateway.metadata.namespace }}
-        data:
-          valueIntermediate: {{ (index .Resources.configMapTestSource 0).data.valueToRead1NonExisting }}
-`
-
-var _ = Describe("Gateway controller", func() {
-
-	const (
-		timeout  = time.Second * 10
-		interval = time.Millisecond * 250
-	)
-
-	var (
-		gwc  *gatewayapi.GatewayClass
-		gwcb *gwcapi.GatewayClassBlueprint
-		ctx  context.Context
-	)
-
-	BeforeEach(func() {
-		gwc = &gatewayapi.GatewayClass{}
-		gwcb = &gwcapi.GatewayClassBlueprint{}
-		ctx = context.Background()
-		Expect(yaml.Unmarshal([]byte(gatewayClassManifest), gwc)).To(Succeed())
-		Expect(k8sClient.Create(ctx, gwc)).Should(Succeed())
-		Expect(yaml.Unmarshal([]byte(gatewayClassBlueprintManifest), gwcb)).To(Succeed())
-		Expect(k8sClient.Create(ctx, gwcb)).Should(Succeed())
-	})
-
-	AfterEach(func() {
-		Expect(k8sClient.Delete(ctx, gwc)).Should(Succeed())
-		Expect(k8sClient.Delete(ctx, gwcb)).Should(Succeed())
-	})
-
-	When("Reconciling a parent Gateway", func() {
-		var childGateway, gw *gatewayapi.Gateway
-
-		BeforeEach(func() {
-			gw = &gatewayapi.Gateway{}
-			childGateway = &gatewayapi.Gateway{}
-			Expect(yaml.Unmarshal([]byte(gatewayManifest), gw)).To(Succeed())
-		})
-
-		It("Should lifecycle correctly", func() {
-
-			By("Creating the gateway")
-			Expect(k8sClient.Create(ctx, gw)).Should(Succeed())
-			Expect(string(gw.Spec.GatewayClassName)).To(Equal("default"))
-
-			gwNN := types.NamespacedName{Name: gw.ObjectMeta.Name, Namespace: gw.ObjectMeta.Namespace}
-			gwChildNN := types.NamespacedName{Name: gw.ObjectMeta.Name + "-istio", Namespace: gw.ObjectMeta.Namespace}
-
-			By("Creating the child gateway")
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, gwChildNN, childGateway)
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, gw)).Should(Succeed())
-			})
-
-			By("Setting the owner reference to enable garbage collection")
-			t := true
-			expectedOwnerReference := metav1.OwnerReference{
-				Kind:               "Gateway",
-				APIVersion:         "gateway.networking.k8s.io/v1",
-				UID:                gw.ObjectMeta.GetUID(),
-				Name:               gw.ObjectMeta.Name,
-				Controller:         &t,
-				BlockOwnerDeletion: &t,
-			}
-			Expect(childGateway.ObjectMeta.OwnerReferences).To(ContainElement(expectedOwnerReference))
-
-			By("Updating conditions")
-
-			// Set child status to not ready
-			Expect(setGatewayStatus(gwChildNN, &metav1.Condition{
-				Type:   string(gatewayapi.GatewayConditionReady),
-				Status: metav1.ConditionFalse,
-				//nolint:staticcheck // ready status is deprecated in gw-api 0.7.0 but since our implementation fits pre-0.7.0 and intended future use we keep the code
-				Reason: string(gatewayapi.GatewayReasonReady)}, nil)).Should(Succeed())
-			time.Sleep(5 * time.Second) // Ensure that controllers cache is updated and we can use 'Consistently' below
-
-			gwRead := &gatewayapi.Gateway{}
-			Consistently(func() bool {
-				err := k8sClient.Get(ctx, gwNN, gwRead)
-				if err != nil {
-					return false
-				}
-				GinkgoT().Logf("gwRead cond: %+v\n", gwRead.Status.Conditions)
-				if kubernetes.ConditionsHaveLatestObservedGeneration(gwRead, gwRead.Status.Conditions) != nil {
-					return false
-				}
-				if !conditionStateIs(gwRead, "Ready", PtrTo(metav1.ConditionFalse), nil, nil) ||
-					!conditionStateIs(gwRead, "Programmed", PtrTo(metav1.ConditionTrue), nil, nil) {
-					return false
-				}
-				return true
-			}, 5*time.Second, interval).Should(BeTrue())
-
-			// Set child status to ready
-			addrType := gatewayapi.IPAddressType
-			Expect(setGatewayStatus(gwChildNN, &metav1.Condition{
-				Type:   string(gatewayapi.GatewayConditionReady),
-				Status: metav1.ConditionTrue,
-				//nolint:staticcheck // ready status is deprecated in gw-api 0.7.0 but since our implementation fits pre-0.7.0 and intended future use we keep the code
-				Reason: string(gatewayapi.GatewayReasonReady)},
-				&gatewayapi.GatewayStatusAddress{Type: &addrType, Value: "4.5.6.7"})).Should(Succeed())
-
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, gwNN, gwRead)
-				if err != nil {
-					return false
-				}
-				GinkgoT().Logf("gwRead cond: %+v\n", gwRead.Status.Conditions)
-				if kubernetes.ConditionsHaveLatestObservedGeneration(gwRead, gwRead.Status.Conditions) != nil {
-					return false
-				}
-				if !conditionStateIs(gwRead, "Ready", PtrTo(metav1.ConditionTrue), nil, nil) ||
-					!conditionStateIs(gwRead, "Programmed", PtrTo(metav1.ConditionTrue), nil, nil) {
-					return false
-				}
-				return true
-			}, timeout, interval).Should(BeTrue())
-
-		})
-
-		It("Should update inter resource-references", func() {
-
-			cm := corev1.ConfigMap{}
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{Name: "dst-configmap", Namespace: "default"}, &cm)
-				return err == nil
-			}, timeout, interval).Should(BeTrue())
-
-			By("Setting the content of the destination configmap")
-			Expect(cm.Data["valueRead"]).To(Equal("HELLO, WORLD"))
-			Expect(cm.Data["valueRead2"]).To(Equal("TESTING, ONE TWO HELLO-THREE"))
-		})
-	})
-})
-
-var _ = Describe("Gateway controller non-ready resources", func() {
-
-	const (
-		timeout  = time.Second * 10
-		interval = time.Millisecond * 250
-	)
-
-	var (
-		gwc  *gatewayapi.GatewayClass
-		gwcb *gwcapi.GatewayClassBlueprint
-		ctx  context.Context
-	)
-
-	BeforeEach(func() {
-		gwc = &gatewayapi.GatewayClass{}
-		gwcb = &gwcapi.GatewayClassBlueprint{}
-		ctx = context.Background()
-		Expect(yaml.Unmarshal([]byte(gatewayClassManifest), gwc)).To(Succeed())
-		Expect(k8sClient.Create(ctx, gwc)).Should(Succeed())
-		Expect(yaml.Unmarshal([]byte(gatewayClassBlueprintManifestNonReady), gwcb)).To(Succeed())
-		Expect(k8sClient.Create(ctx, gwcb)).Should(Succeed())
-	})
-
-	AfterEach(func() {
-		Expect(k8sClient.Delete(ctx, gwc)).Should(Succeed())
-		Expect(k8sClient.Delete(ctx, gwcb)).Should(Succeed())
-	})
-
-	When("Reconciling a parent Gateway", func() {
-		var gw *gatewayapi.Gateway
-
-		BeforeEach(func() {
-			gw = &gatewayapi.Gateway{}
-			Expect(yaml.Unmarshal([]byte(gatewayManifest), gw)).To(Succeed())
-		})
-
-		It("Should lifecycle correctly", func() {
-
-			By("Creating the gateway")
-			Expect(k8sClient.Create(ctx, gw)).Should(Succeed())
-			DeferCleanup(func() {
-				Expect(k8sClient.Delete(ctx, gw)).Should(Succeed())
-			})
-
-			gwNN := types.NamespacedName{Name: gw.ObjectMeta.Name, Namespace: gw.ObjectMeta.Namespace}
-
-			By("Updating conditions")
-
-			gwRead := &gatewayapi.Gateway{}
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, gwNN, gwRead)
-				if err != nil {
-					return false
-				}
-				GinkgoT().Logf("gwRead cond: %+v\n", gwRead.Status.Conditions)
-				if kubernetes.ConditionsHaveLatestObservedGeneration(gwRead, gwRead.Status.Conditions) != nil {
-					return false
-				}
-				if !conditionStateIs(gwRead, "Accepted", PtrTo(metav1.ConditionTrue), nil, nil) ||
-					!conditionStateIs(gwRead, "Ready", PtrTo(metav1.ConditionFalse), nil, nil) ||
-					!conditionStateIs(gwRead, "Programmed", PtrTo(metav1.ConditionFalse), PtrTo("Pending"), PtrTo("missing 1 resources: configMapTestIntermediate1\\[\\]")) {
-					return false
-				}
-				return true
-			}, 5*time.Second, interval).Should(BeTrue())
-		})
-	})
-})
-
+// conditionStateIs is a helper function to check if a Gateway has a condition of a given type, status, reason and message pattern
 func conditionStateIs(gw *gatewayapi.Gateway, condType string, status *metav1.ConditionStatus, reason, messageRegEx *string) bool {
 	var msgMatch *regexp.Regexp
 	if messageRegEx != nil {
@@ -410,10 +67,10 @@ func conditionStateIs(gw *gatewayapi.Gateway, condType string, status *metav1.Co
 			return true
 		}
 	}
-
 	return false
 }
 
+// setGatewayStatus is a helper function to update the status of a Gateway in the test environment
 func setGatewayStatus(nn types.NamespacedName, newCondition *metav1.Condition, address *gatewayapi.GatewayStatusAddress) error {
 	gw := &gatewayapi.Gateway{}
 
@@ -436,3 +93,585 @@ func setGatewayStatus(nn types.NamespacedName, newCondition *metav1.Condition, a
 	}
 	return nil
 }
+
+// Shared resource template used by both ready and non-ready blueprints
+const tmplConfigMapSource = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: source-configmap
+  namespace: {{ .Gateway.metadata.namespace }}
+data:
+  valueToRead1: Hello
+  valueToRead2: World
+`
+
+// newTestGatewayClass returns a GatewayClass with a reference to the default test GatewayClassBlueprint
+func newTestGatewayClass() *gatewayapi.GatewayClass {
+	return &gatewayapi.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+		Spec: gatewayapi.GatewayClassSpec{
+			ControllerName: "github.com/tv2/bifrost-gateway-controller",
+			ParametersRef: &gatewayapi.ParametersReference{
+				Group: "gateway.tv2.dk",
+				Kind:  "GatewayClassBlueprint",
+				Name:  "default-gateway-class",
+			},
+		},
+	}
+}
+
+// newTestGateway returns a Gateway with a reference to the default test GatewayClass
+func newTestGateway() *gatewayapi.Gateway {
+	hostname := gatewayapi.Hostname("example.com")
+	return &gatewayapi.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo-gateway", Namespace: "default"},
+		Spec: gatewayapi.GatewaySpec{
+			GatewayClassName: "default",
+			Listeners: []gatewayapi.Listener{{
+				Name:     "prod-web",
+				Port:     80,
+				Protocol: gatewayapi.HTTPProtocolType,
+				Hostname: &hostname,
+			}},
+		},
+	}
+}
+
+// newTestBlueprint returns a GatewayClassBlueprint with templates that
+// reference each other to test inter-resource referencing and value inheritance
+func newTestBlueprint() *gwcapi.GatewayClassBlueprint {
+	return &gwcapi.GatewayClassBlueprint{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-gateway-class"},
+		Spec: gwcapi.GatewayClassBlueprintSpec{
+			Values: gwcapi.TemplateValues{
+				Default: jsonRaw(`{"configmap2SuffixData":["one","two","three"]}`),
+			},
+			GatewayTemplate: gwcapi.ResourceSpec{
+				ResourceStatusSpec: gwcapi.ResourceStatusSpec{
+					Status: map[string]string{
+						"template": "addresses:\n  {{ toYaml (index .Resources.childGateway 0).status.addresses | nindent 2}}\n",
+					},
+				},
+				ResourceTemplate: gwcapi.ResourceTemplate{
+					ResourceTemplates: map[string]string{
+						"childGateway": `apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: {{ .Gateway.metadata.name }}-istio
+  namespace: {{ .Gateway.metadata.namespace }}
+  annotations:
+    networking.istio.io/service-type: ClusterIP
+spec:
+  gatewayClassName: istio
+  listeners:
+    {{- toYaml .Gateway.spec.listeners | nindent 6 }}
+`,
+						"configMapTestSource": tmplConfigMapSource,
+						"configMapTestIntermediate1": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: intermediate1-configmap
+  namespace: {{ .Gateway.metadata.namespace }}
+data:
+  valueIntermediate: {{ (index .Resources.configMapTestSource 0).data.valueToRead1 }}
+`,
+						"configMapTestIntermediate2": `{{ range $idx,$suffix := .Values.configmap2SuffixData }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: intermediate2-configmap-{{ $idx }}
+  namespace: {{ $.Gateway.metadata.namespace }}
+data:
+  valueIntermediate: {{ (index $.Resources.configMapTestSource 0).data.valueToRead1 }}-{{ $suffix }}
+---
+{{ end }}
+`,
+						"configMapTestDestination": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dst-configmap
+  namespace: {{ .Gateway.metadata.namespace }}
+data:
+  valueRead: {{ printf "%s, %s" (index .Resources.configMapTestIntermediate1 0).data.valueIntermediate (index .Resources.configMapTestSource 0).data.valueToRead2 | upper }}
+  valueRead2: {{ printf "Testing, one two %s" (index .Resources.configMapTestIntermediate2 2).data.valueIntermediate | upper }}
+`,
+					},
+				},
+			},
+			HTTPRouteTemplate: gwcapi.ResourceSpec{
+				ResourceTemplate: gwcapi.ResourceTemplate{
+					ResourceTemplates: map[string]string{
+						"shadowHttproute": `apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: {{ .HTTPRoute.metadata.name }}-istio
+  namespace: {{ .HTTPRoute.metadata.namespace }}
+spec:
+  parentRefs:
+  {{ range .HTTPRoute.spec.parentRefs }}
+  - kind: {{ .kind }}
+    name: {{ .name }}-istio
+    namespace: {{ .namespace }}
+  {{ end }}
+  rules:
+  {{ toYaml .HTTPRoute.spec.rules | nindent 4 }}
+`,
+					},
+				},
+			},
+		},
+	}
+}
+
+// newTestBlueprintNonReady returns a GatewayClassBlueprint with templates that
+// reference each other but have a missing value reference to simulate a
+// non-ready child resource
+func newTestBlueprintNonReady() *gwcapi.GatewayClassBlueprint {
+	return &gwcapi.GatewayClassBlueprint{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-gateway-class"},
+		Spec: gwcapi.GatewayClassBlueprintSpec{
+			GatewayTemplate: gwcapi.ResourceSpec{
+				ResourceTemplate: gwcapi.ResourceTemplate{
+					ResourceTemplates: map[string]string{
+						"configMapTestSource": tmplConfigMapSource,
+						"configMapTestIntermediate1": `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: intermediate1-configmap
+  namespace: {{ .Gateway.metadata.namespace }}
+data:
+  valueIntermediate: {{ (index .Resources.configMapTestSource 0).data.valueToRead1NonExisting }}
+`,
+					},
+				},
+			},
+		},
+	}
+}
+
+// ------------------------------------
+// [combineHostnames] tests
+// ------------------------------------
+
+var _ = Describe("combineHostnames", func() {
+	// gwWith is a helper to create a Gateway with listeners having the given hostnames
+	gwWith := func(hostnames ...string) *gatewayapi.Gateway {
+		gw := &gatewayapi.Gateway{}
+		for _, h := range hostnames {
+			hn := gatewayapi.Hostname(h)
+			gw.Spec.Listeners = append(gw.Spec.Listeners, gatewayapi.Listener{
+				Name:     gatewayapi.SectionName("l"),
+				Hostname: &hn,
+			})
+		}
+		return gw
+	}
+
+	// rtWith is a helper to create an HTTPRoute with the given hostnames
+	rtWith := func(ns string, hostnames ...string) *gatewayapi.HTTPRoute {
+		rt := &gatewayapi.HTTPRoute{}
+		rt.Namespace = ns
+		for _, h := range hostnames {
+			rt.Spec.Hostnames = append(rt.Spec.Hostnames, gatewayapi.Hostname(h))
+		}
+		return rt
+	}
+
+	It("Should return empty slices (nil) when no hostnames", func() {
+		gw := &gatewayapi.Gateway{
+			Spec: gatewayapi.GatewaySpec{
+				Listeners: []gatewayapi.Listener{{Name: "l"}},
+			},
+		}
+		union, isect := combineHostnames(gw, nil)
+		Expect(union).To(BeNil())
+		Expect(isect).To(BeNil())
+	})
+
+	It("Should return a single hostname in both union and intersection", func() {
+		gw := gwWith("example.com")
+		union, isect := combineHostnames(gw, nil)
+		Expect(union).To(ConsistOf("example.com"))
+		Expect(isect).To(ConsistOf("example.com"))
+	})
+
+	It("Should deduplicate identical hostnames from listener and route", func() {
+		gw := gwWith("example.com")
+		rt := rtWith("default", "example.com")
+		union, isect := combineHostnames(gw, []*gatewayapi.HTTPRoute{rt})
+		Expect(union).To(ConsistOf("example.com"))
+		Expect(isect).To(ConsistOf("example.com"))
+	})
+
+	It("Should exclude route hostname from intersection when covered by wildcard", func() {
+		gw := gwWith("*.example.com")
+		rt := rtWith("default", "foo.example.com")
+		union, isect := combineHostnames(gw, []*gatewayapi.HTTPRoute{rt})
+		sort.Strings(union)
+		Expect(union).To(ConsistOf("*.example.com", "foo.example.com"))
+		Expect(isect).To(ConsistOf("*.example.com"))
+	})
+
+	It("Should keep non-covered hostname in intersection", func() {
+		gw := gwWith("*.example.com")
+		rt := rtWith("default", "other.org")
+		union, isect := combineHostnames(gw, []*gatewayapi.HTTPRoute{rt})
+		Expect(union).To(ConsistOf("*.example.com", "other.org"))
+		Expect(isect).To(ConsistOf("*.example.com", "other.org"))
+	})
+
+	It("Should handle multiple wildcards and mixed hostnames", func() {
+		gw := gwWith("*.example.com", "*.test.io")
+		rt := rtWith("default", "foo.example.com", "bar.test.io", "other.org")
+		union, isect := combineHostnames(gw, []*gatewayapi.HTTPRoute{rt})
+		Expect(union).To(ConsistOf("*.example.com", "*.test.io", "foo.example.com", "bar.test.io", "other.org"))
+		Expect(isect).To(ConsistOf("*.example.com", "*.test.io", "other.org"))
+	})
+
+	It("Should include route hostnames from multiple routes", func() {
+		gw := gwWith("example.com")
+		rt1 := rtWith("default", "a.example.com")
+		rt2 := rtWith("default", "b.example.com")
+		union, isect := combineHostnames(gw, []*gatewayapi.HTTPRoute{rt1, rt2})
+		Expect(union).To(ConsistOf("example.com", "a.example.com", "b.example.com"))
+		Expect(isect).To(ConsistOf("example.com", "a.example.com", "b.example.com"))
+	})
+
+	It("Should handle listeners without hostname", func() {
+		gw := &gatewayapi.Gateway{
+			Spec: gatewayapi.GatewaySpec{
+				Listeners: []gatewayapi.Listener{{Name: "l"}},
+			},
+		}
+		rt := rtWith("default", "example.com")
+		union, isect := combineHostnames(gw, []*gatewayapi.HTTPRoute{rt})
+		Expect(union).To(ConsistOf("example.com"))
+		Expect(isect).To(ConsistOf("example.com"))
+	})
+})
+
+// ------------------------------------
+// [filterHTTPRoutesForGateway] tests
+// ------------------------------------
+
+var _ = Describe("filterHTTPRoutesForGateway", func() {
+	// rtWithRef is a helper to create an HTTPRoute with a parent ref to a gateway with the given name and namespace
+	rtWithRef := func(name, ns string, parentName gatewayapi.ObjectName, parentNs *gatewayapi.Namespace, parentGroup *gatewayapi.Group, parentKind *gatewayapi.Kind) *gatewayapi.HTTPRoute {
+		return &gatewayapi.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: gatewayapi.HTTPRouteSpec{
+				CommonRouteSpec: gatewayapi.CommonRouteSpec{
+					ParentRefs: []gatewayapi.ParentReference{{
+						Group:     parentGroup,
+						Kind:      parentKind,
+						Name:      parentName,
+						Namespace: parentNs,
+					}},
+				},
+			},
+		}
+	}
+
+	gw := &gatewayapi.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-gw", Namespace: "default"},
+	}
+
+	It("Should match route with matching name and same namespace", func() {
+		rt := rtWithRef("rt1", "default", "my-gw", nil, nil, nil)
+		result := filterHTTPRoutesForGateway(gw, []*gatewayapi.HTTPRoute{rt})
+		Expect(result[0].Name).To(Equal("rt1"))
+	})
+
+	It("Should match route with explicit matching namespace", func() {
+		ns := gatewayapi.Namespace("default")
+		rt := rtWithRef("rt1", "default", "my-gw", &ns, nil, nil)
+		result := filterHTTPRoutesForGateway(gw, []*gatewayapi.HTTPRoute{rt})
+		Expect(result).To(HaveLen(1))
+	})
+
+	It("Should not match route targeting different gateway name", func() {
+		rt := rtWithRef("rt1", "default", "other-gw", nil, nil, nil)
+		result := filterHTTPRoutesForGateway(gw, []*gatewayapi.HTTPRoute{rt})
+		Expect(result).To(BeEmpty())
+	})
+
+	It("Should not match route in different namespace (implicit)", func() {
+		rt := rtWithRef("rt1", "other-ns", "my-gw", nil, nil, nil)
+		result := filterHTTPRoutesForGateway(gw, []*gatewayapi.HTTPRoute{rt})
+		Expect(result).To(BeEmpty())
+	})
+
+	It("Should not match route with explicit wrong namespace", func() {
+		ns := gatewayapi.Namespace("other-ns")
+		rt := rtWithRef("rt1", "default", "my-gw", &ns, nil, nil)
+		result := filterHTTPRoutesForGateway(gw, []*gatewayapi.HTTPRoute{rt})
+		Expect(result).To(BeEmpty())
+	})
+
+	It("Should match correct group and reject wrong group", func() {
+		wrongGroup := gatewayapi.Group("wrong.group")
+		rt := rtWithRef("rt1", "default", "my-gw", nil, &wrongGroup, nil)
+		Expect(filterHTTPRoutesForGateway(gw, []*gatewayapi.HTTPRoute{rt})).To(BeEmpty())
+
+		correctGroup := gatewayapi.Group(gatewayapi.GroupName)
+		rt2 := rtWithRef("rt2", "default", "my-gw", nil, &correctGroup, nil)
+		Expect(filterHTTPRoutesForGateway(gw, []*gatewayapi.HTTPRoute{rt2})).To(HaveLen(1))
+	})
+
+	It("Should match correct kind and reject wrong kind", func() {
+		wrongKind := gatewayapi.Kind("Service")
+		rt := rtWithRef("rt1", "default", "my-gw", nil, nil, &wrongKind)
+		Expect(filterHTTPRoutesForGateway(gw, []*gatewayapi.HTTPRoute{rt})).To(BeEmpty())
+
+		correctKind := gatewayapi.Kind("Gateway")
+		rt2 := rtWithRef("rt2", "default", "my-gw", nil, nil, &correctKind)
+		Expect(filterHTTPRoutesForGateway(gw, []*gatewayapi.HTTPRoute{rt2})).To(HaveLen(1))
+	})
+
+	It("Should filter from multiple routes keeping only matches", func() {
+		rt1 := rtWithRef("match1", "default", "my-gw", nil, nil, nil)
+		rt2 := rtWithRef("nomatch", "default", "other-gw", nil, nil, nil)
+		rt3 := rtWithRef("match2", "default", "my-gw", nil, nil, nil)
+		result := filterHTTPRoutesForGateway(gw, []*gatewayapi.HTTPRoute{rt1, rt2, rt3})
+		Expect(result).To(HaveLen(2))
+		Expect(result[0].Name).To(Equal("match1"))
+		Expect(result[1].Name).To(Equal("match2"))
+	})
+
+	It("Should return empty slice for empty input", func() {
+		result := filterHTTPRoutesForGateway(gw, nil)
+		Expect(result).To(BeEmpty())
+	})
+
+	It("Should handle route with no parent refs", func() {
+		rt := &gatewayapi.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "rt1", Namespace: "default"},
+		}
+		result := filterHTTPRoutesForGateway(gw, []*gatewayapi.HTTPRoute{rt})
+		Expect(result).To(BeEmpty())
+	})
+})
+
+// ------------------------------------
+// [lookupHTTPRoutes] tests
+// ------------------------------------
+
+var _ = Describe("lookupHTTPRoutes", func() {
+
+	It("Should return empty slice when no routes exist", func() {
+		r := newFakeClient()
+		routes, err := lookupHTTPRoutes(context.Background(), r)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(routes).To(BeEmpty())
+	})
+
+	It("Should return all routes from the cluster", func() {
+		rt1 := &gatewayapi.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "rt1", Namespace: "default"}}
+		rt2 := &gatewayapi.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "rt2", Namespace: "other"}}
+		r := newFakeClient(rt1, rt2)
+		routes, err := lookupHTTPRoutes(context.Background(), r)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(routes[0].Name).To(Equal("rt1"))
+		Expect(routes[1].Name).To(Equal("rt2"))
+	})
+})
+
+// ------------------------------------
+// Integration tests
+// ------------------------------------
+
+var _ = Describe("Gateway controller", func() {
+
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	var (
+		gwc  *gatewayapi.GatewayClass
+		gwcb *gwcapi.GatewayClassBlueprint
+		ctx  context.Context
+	)
+
+	BeforeEach(func() {
+		// Before each test, create a shared default GatewayClass and a shared
+		// GatewayClassBlueprint that the test Gateways will reference.
+		ctx = context.Background()
+		gwc = newTestGatewayClass()
+		Expect(k8sClient.Create(ctx, gwc)).Should(Succeed())
+		gwcb = newTestBlueprint()
+		Expect(k8sClient.Create(ctx, gwcb)).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		// After each test, clean up the created GatewayClass and
+		// GatewayClassBlueprint to avoid interference with other tests.
+		Expect(k8sClient.Delete(ctx, gwc)).Should(Succeed())
+		Expect(k8sClient.Delete(ctx, gwcb)).Should(Succeed())
+	})
+
+	When("Reconciling a parent Gateway", func() {
+		var gw *gatewayapi.Gateway
+
+		BeforeEach(func() {
+			// Create a Gateway that will be used in the "Reconciling a parent
+			// Gateway" tests. This Gateway references the shared default
+			// GatewayClass and should trigger the creation of a child Gateway
+			// and the ConfigMaps defined in the blueprint.
+			gw = newTestGateway()
+			Expect(k8sClient.Create(ctx, gw)).Should(Succeed()) // create the parent Gateway
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, gw)).Should(Succeed()) // when test finishes, delete the parent Gateway and expect the child and configmaps to be garbage collected
+			})
+		})
+
+		It("Should set owner reference on child gateway for garbage collection", func() {
+			childGateway := &gatewayapi.Gateway{}
+			gwChildNN := types.NamespacedName{Name: gw.ObjectMeta.Name + "-istio", Namespace: gw.ObjectMeta.Namespace}
+
+			// Wait for child gateway to exist and have the correct owner
+			// reference pointing to the parent gateway for garbage collection
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, gwChildNN, childGateway); err != nil {
+					return false
+				}
+				for _, ref := range childGateway.ObjectMeta.OwnerReferences {
+					if ref.UID == gw.ObjectMeta.GetUID() {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			t := true
+			expectedOwnerReference := metav1.OwnerReference{
+				Kind:               "Gateway",
+				APIVersion:         "gateway.networking.k8s.io/v1",
+				UID:                gw.ObjectMeta.GetUID(),
+				Name:               gw.ObjectMeta.Name,
+				Controller:         &t,
+				BlockOwnerDeletion: &t,
+			}
+			Expect(childGateway.ObjectMeta.OwnerReferences).To(ContainElement(expectedOwnerReference))
+		})
+
+		It("Should set Ready=false when child gateway is not ready", func() {
+			gwNN := types.NamespacedName{Name: gw.ObjectMeta.Name, Namespace: gw.ObjectMeta.Namespace}
+			gwChildNN := types.NamespacedName{Name: gw.ObjectMeta.Name + "-istio", Namespace: gw.ObjectMeta.Namespace}
+
+			// Wait for child to exist
+			Eventually(func() bool {
+				return k8sClient.Get(ctx, gwChildNN, &gatewayapi.Gateway{}) == nil
+			}, timeout, interval).Should(BeTrue())
+
+			Expect(setGatewayStatus(gwChildNN, &metav1.Condition{
+				Type:   string(gatewayapi.GatewayConditionReady),
+				Status: metav1.ConditionFalse,
+				//nolint:staticcheck
+				Reason: string(gatewayapi.GatewayReasonReady)}, nil)).Should(Succeed())
+			time.Sleep(5 * time.Second)
+
+			gwRead := &gatewayapi.Gateway{}
+			Consistently(func() bool {
+				err := k8sClient.Get(ctx, gwNN, gwRead)
+				if err != nil {
+					return false
+				}
+				if kubernetes.ConditionsHaveLatestObservedGeneration(gwRead, gwRead.Status.Conditions) != nil {
+					return false
+				}
+				return conditionStateIs(gwRead, "Ready", PtrTo(metav1.ConditionFalse), nil, nil) &&
+					conditionStateIs(gwRead, "Programmed", PtrTo(metav1.ConditionTrue), nil, nil)
+			}, 5*time.Second, interval).Should(BeTrue())
+		})
+
+		It("Should set Ready=true and propagate address when child gateway is ready", func() {
+			gwNN := types.NamespacedName{Name: gw.ObjectMeta.Name, Namespace: gw.ObjectMeta.Namespace}
+			gwChildNN := types.NamespacedName{Name: gw.ObjectMeta.Name + "-istio", Namespace: gw.ObjectMeta.Namespace}
+
+			// Wait for child to exist
+			Eventually(func() bool {
+				return k8sClient.Get(ctx, gwChildNN, &gatewayapi.Gateway{}) == nil
+			}, timeout, interval).Should(BeTrue())
+
+			addrType := gatewayapi.IPAddressType
+			Expect(setGatewayStatus(gwChildNN, &metav1.Condition{
+				Type:   string(gatewayapi.GatewayConditionReady),
+				Status: metav1.ConditionTrue,
+				//nolint:staticcheck
+				Reason: string(gatewayapi.GatewayReasonReady)},
+				&gatewayapi.GatewayStatusAddress{Type: &addrType, Value: "4.5.6.7"})).Should(Succeed())
+
+			gwRead := &gatewayapi.Gateway{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, gwNN, gwRead)
+				if err != nil {
+					return false
+				}
+				if kubernetes.ConditionsHaveLatestObservedGeneration(gwRead, gwRead.Status.Conditions) != nil {
+					return false
+				}
+				return conditionStateIs(gwRead, "Ready", PtrTo(metav1.ConditionTrue), nil, nil) &&
+					conditionStateIs(gwRead, "Programmed", PtrTo(metav1.ConditionTrue), nil, nil)
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("Should resolve inter resource-references in ConfigMap chain", func() {
+			cm := corev1.ConfigMap{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "dst-configmap", Namespace: "default"}, &cm)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			Expect(cm.Data["valueRead"]).To(Equal("HELLO, WORLD"))
+			Expect(cm.Data["valueRead2"]).To(Equal("TESTING, ONE TWO HELLO-THREE"))
+		})
+
+		It("Should set Accepted=true on the parent gateway", func() {
+			gwNN := types.NamespacedName{Name: gw.ObjectMeta.Name, Namespace: gw.ObjectMeta.Namespace}
+			gwRead := &gatewayapi.Gateway{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, gwNN, gwRead)
+				if err != nil {
+					return false
+				}
+				return conditionStateIs(gwRead, "Accepted", PtrTo(metav1.ConditionTrue), nil, nil)
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	When("Blueprint produces a resource that cannot render", func() {
+		BeforeEach(func() {
+			// Override the blueprint with the non-ready variant
+			Expect(k8sClient.Delete(ctx, gwcb)).Should(Succeed())
+			gwcb = newTestBlueprintNonReady()
+			Expect(k8sClient.Create(ctx, gwcb)).Should(Succeed())
+		})
+
+		It("Should report Programmed=false with missing resource message", func() {
+			gw := newTestGateway()
+			Expect(k8sClient.Create(ctx, gw)).Should(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, gw)).Should(Succeed())
+			})
+
+			gwNN := types.NamespacedName{Name: gw.ObjectMeta.Name, Namespace: gw.ObjectMeta.Namespace}
+			gwRead := &gatewayapi.Gateway{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, gwNN, gwRead)
+				if err != nil {
+					return false
+				}
+				if kubernetes.ConditionsHaveLatestObservedGeneration(gwRead, gwRead.Status.Conditions) != nil {
+					return false
+				}
+				return conditionStateIs(gwRead, "Accepted", PtrTo(metav1.ConditionTrue), nil, nil) &&
+					conditionStateIs(gwRead, "Ready", PtrTo(metav1.ConditionFalse), nil, nil) &&
+					conditionStateIs(gwRead, "Programmed", PtrTo(metav1.ConditionFalse), PtrTo("Pending"), PtrTo("missing 1 resources: configMapTestIntermediate1\\[\\]"))
+			}, 5*time.Second, interval).Should(BeTrue())
+		})
+	})
+})

--- a/controllers/gatewayclass_controller_test.go
+++ b/controllers/gatewayclass_controller_test.go
@@ -120,7 +120,7 @@ spec:
 }
 
 // conditionByType returns the first condition matching the given type, or nil.
-func conditionByType(conditions []metav1.Condition, condType string) *metav1.Condition {
+func conditionByType(conditions []metav1.Condition, condType string) *metav1.Condition { //nolint:unparam // condType is always the same in current tests but kept for reusability
 	for i := range conditions {
 		if conditions[i].Type == condType {
 			return &conditions[i]

--- a/controllers/gatewayclass_controller_test.go
+++ b/controllers/gatewayclass_controller_test.go
@@ -39,76 +39,118 @@ import (
 	. "github.com/onsi/gomega"
 
 	gwcapi "github.com/tv2/bifrost-gateway-controller/apis/gateway.tv2.dk/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/yaml"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-const gatewayclassManifest string = `
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: GatewayClass
-metadata:
-  name: cloud-gw
-spec:
-  controllerName: "github.com/tv2/bifrost-gateway-controller"
-  parametersRef:
-    group: gateway.tv2.dk
-    kind: GatewayClassBlueprint
-    name: default-gateway-class`
+// ------------------------------------
+// Test Helpers
+// ------------------------------------
 
-const gatewayclassManifestInvalid string = `
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: GatewayClass
-metadata:
-  name: cloud-gw-invalid
-spec:
-  controllerName: "github.com/tv2/bifrost-gateway-controller"`
+// newGatewayClassWithBlueprint returns a GatewayClass named "default-gateway-class".
+// This GatewayClass has a ParametersRef that points to a GatewayClassBlueprint named
+func newGatewayClassWithBlueprint() *gatewayapi.GatewayClass {
+	return &gatewayapi.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cloud-gw"},
+		Spec: gatewayapi.GatewayClassSpec{
+			ControllerName: "github.com/tv2/bifrost-gateway-controller",
+			ParametersRef: &gatewayapi.ParametersReference{
+				Group: "gateway.tv2.dk",
+				Kind:  "GatewayClassBlueprint",
+				Name:  "default-gateway-class",
+			},
+		},
+	}
+}
 
-const gatewayclassManifestNotOurs string = `
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: GatewayClass
-metadata:
-  name: not-our-gatewayclass
-spec:
-  controllerName: "github.com/acme/bifrost-gateway-controller"`
+// newGatewayClassNoParams returns a GatewayClass named "cloud-gw-invalid" that
+// has no ParametersRef. This is invalid because our controller requires a
+// ParametersRef to a GatewayClassBlueprint in order to function, so we expect
+// the controller to mark this GatewayClass as invalid when it processes it.
+func newGatewayClassNoParams() *gatewayapi.GatewayClass {
+	return &gatewayapi.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cloud-gw-invalid"},
+		Spec: gatewayapi.GatewayClassSpec{
+			ControllerName: "github.com/tv2/bifrost-gateway-controller",
+		},
+	}
+}
 
-const gwClassBlueprintManifest string = `
-apiVersion: gateway.tv2.dk/v1alpha1
-kind: GatewayClassBlueprint
+// newGatewayClassNotOurs returns a GatewayClass named "not-our-gatewayclass"
+// that specifies a controller name that does not match our controller. This is
+// used to test that our controller correctly ignores GatewayClasses that it
+// does not own, and does not mark them as accepted or invalid.
+func newGatewayClassNotOurs() *gatewayapi.GatewayClass {
+	return &gatewayapi.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "not-our-gatewayclass"},
+		Spec: gatewayapi.GatewayClassSpec{
+			ControllerName: "github.com/acme/bifrost-gateway-controller",
+		},
+	}
+}
+
+// newMinimalBlueprint returns a minimal valid GatewayClassBlueprint that can be
+// used in tests.
+func newMinimalBlueprint() *gwcapi.GatewayClassBlueprint {
+	return &gwcapi.GatewayClassBlueprint{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-gateway-class"},
+		Spec: gwcapi.GatewayClassBlueprintSpec{
+			GatewayTemplate: gwcapi.ResourceSpec{
+				ResourceTemplate: gwcapi.ResourceTemplate{
+					ResourceTemplates: map[string]string{
+						"istioShadowGw": `apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
 metadata:
-  name: default-gateway-class
+  name: {{ .Gateway.ObjectMeta.Name }}-istio
+  namespace: {{ .Gateway.metadata.namespace }}
+  annotations:
+    networking.istio.io/service-type: ClusterIP
 spec:
-  gatewayTemplate:
-    resourceTemplates:
-      istioShadowGw: |
-        apiVersion: gateway.networking.k8s.io/v1beta1
-        kind: Gateway
-        metadata:
-          name: {{ .Gateway.ObjectMeta.Name }}-istio
-          namespace: {{ .Gateway.metadata.namespace }}
-          annotations:
-            networking.istio.io/service-type: ClusterIP
-        spec:
-          gatewayClassName: istio
-          listeners:
-            {{- toYaml .Gateway.spec.listeners | nindent 6 }}
-  httpRouteTemplate:
-    resourceTemplates:
-      shadowHttproute: |
-        apiVersion: gateway.networking.k8s.io/v1beta1
-        kind: HTTPRoute
-        metadata:
-          name: {{ .HTTPRoute.ObjectMeta.Name }}-istio
-          namespace: {{ .HTTPRoute.metadata.namespace }}
-        spec:
-          parentRefs:
-          {{ range .HTTPRoute.spec.parentRefs }}
-          - kind: {{ .kind }}
-            name: {{ .name }}-istio
-            namespace: {{ .namespace }}
-          {{ end }}
-          rules:
-          {{ toYaml .HTTPRoute.spec.rules | nindent 4 }}`
+  gatewayClassName: istio
+  listeners:
+    {{- toYaml .Gateway.spec.listeners | nindent 6 }}
+`,
+					},
+				},
+			},
+		},
+	}
+}
+
+// conditionByType returns the first condition matching the given type, or nil.
+func conditionByType(conditions []metav1.Condition, condType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == condType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+// ------------------------------------
+// [GatewayClassReconciler] accessor tests
+// ------------------------------------
+
+var _ = Describe("GatewayClassReconciler", func() {
+
+	It("Should return the client it was constructed with", func() {
+		cl := newFakeClient().Client()
+		r := &GatewayClassReconciler{client: cl}
+		Expect(r.Client()).To(Equal(cl))
+	})
+
+	It("Should return the scheme it was constructed with", func() {
+		s := runtime.NewScheme()
+		r := &GatewayClassReconciler{scheme: s}
+		Expect(r.Scheme()).To(Equal(s))
+	})
+})
+
+// ------------------------------------
+// Integration tests
+// ------------------------------------
 
 var _ = Describe("GatewayClass controller", func() {
 
@@ -117,90 +159,103 @@ var _ = Describe("GatewayClass controller", func() {
 		interval = time.Millisecond * 250
 	)
 
-	var (
-		gwcIn, gwc *gatewayapi.GatewayClass
-		gwcb       *gwcapi.GatewayClassBlueprint
-		ctx        context.Context
-	)
-
-	BeforeEach(func() {
-		ctx = context.Background()
-		gwcIn = &gatewayapi.GatewayClass{}
-		gwc = &gatewayapi.GatewayClass{}
-		gwcb = &gwcapi.GatewayClassBlueprint{}
-	})
+	ctx := context.Background()
 
 	When("A gatewayclass we own is created", func() {
+		var gwc *gatewayapi.GatewayClass
+		var gwcb *gwcapi.GatewayClassBlueprint
+
+		BeforeEach(func() {
+			gwcb = newMinimalBlueprint()
+			Expect(k8sClient.Create(ctx, gwcb)).Should(Succeed())
+			gwc = newGatewayClassWithBlueprint()
+			Expect(k8sClient.Create(ctx, gwc)).Should(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, gwc)).Should(Succeed())
+				Expect(k8sClient.Delete(ctx, gwcb)).Should(Succeed())
+			})
+		})
 
 		It("Should be marked as accepted", func() {
+			nn := types.NamespacedName{Name: gwc.Name}
+			fetched := &gatewayapi.GatewayClass{}
 
-			err := yaml.Unmarshal([]byte(gatewayclassManifest), gwcIn)
-			Expect(err).Should(Succeed())
-			Expect(k8sClient.Create(ctx, gwcIn)).Should(Succeed())
-
-			Expect(yaml.Unmarshal([]byte(gwClassBlueprintManifest), gwcb)).To(Succeed())
-			Expect(k8sClient.Create(ctx, gwcb)).Should(Succeed())
-
-			lookupKey := types.NamespacedName{Name: gwcIn.ObjectMeta.Name, Namespace: ""}
-
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, lookupKey, gwc)
-				if err != nil ||
-					gwc.Status.Conditions[0].Type != string(gatewayapi.GatewayClassConditionStatusAccepted) ||
-					gwc.Status.Conditions[0].Status != "True" {
-					return false
-				}
-				return true
-			}, timeout, interval).Should(BeTrue())
-
-			Expect(k8sClient.Delete(ctx, gwcIn)).Should(Succeed())
-			Expect(k8sClient.Delete(ctx, gwcb)).Should(Succeed())
+			// Use Eventually here to wait for the controller to process the
+			// newly created GatewayClass and update its status with the
+			// Accepted condition. This is necessary because the controller
+			// processes resources asynchronously.
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, nn, fetched)).To(Succeed())
+				cond := conditionByType(fetched.Status.Conditions, string(gatewayapi.GatewayClassConditionStatusAccepted))
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(cond.Reason).To(Equal(string(gatewayapi.GatewayClassReasonAccepted)))
+			}, timeout, interval).Should(Succeed())
 		})
 	})
 
 	When("An invalid gatewayclass we own is created", func() {
+		var gwc *gatewayapi.GatewayClass
+
+		BeforeEach(func() {
+			gwc = newGatewayClassNoParams()
+			Expect(k8sClient.Create(ctx, gwc)).Should(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, gwc)).Should(Succeed())
+			})
+		})
+
 		It("Should be marked as invalid", func() {
+			nn := types.NamespacedName{Name: gwc.Name}
+			fetched := &gatewayapi.GatewayClass{}
 
-			err := yaml.Unmarshal([]byte(gatewayclassManifestInvalid), gwcIn)
-			Expect(err).Should(Succeed())
-			Expect(k8sClient.Create(ctx, gwcIn)).Should(Succeed())
-
-			lookupKey := types.NamespacedName{Name: gwcIn.ObjectMeta.Name, Namespace: ""}
-
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, lookupKey, gwc)
-				if err != nil ||
-					gwc.Status.Conditions[0].Type != string(gatewayapi.GatewayClassConditionStatusAccepted) ||
-					gwc.Status.Conditions[0].Status != "False" ||
-					gwc.Status.Conditions[0].Reason != string(gatewayapi.GatewayClassReasonInvalidParameters) {
-					return false
-				}
-				return true
-			}, timeout, interval).Should(BeTrue())
-
-			Expect(k8sClient.Delete(ctx, gwcIn)).Should(Succeed())
+			// Use Eventually here to wait for the controller to process the
+			// newly created invalid GatewayClass and update its status with the
+			// Accepted=false condition and the appropriate reason. This is
+			// necessary because the controller processes resources
+			// asynchronously.
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, nn, fetched)).To(Succeed())
+				cond := conditionByType(fetched.Status.Conditions, string(gatewayapi.GatewayClassConditionStatusAccepted))
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(Equal(string(gatewayapi.GatewayClassReasonInvalidParameters)))
+			}, timeout, interval).Should(Succeed())
 		})
 	})
 
 	When("A gatewayclass we do not own is created", func() {
+		var gwc *gatewayapi.GatewayClass
+
+		BeforeEach(func() {
+			gwc = newGatewayClassNotOurs()
+			Expect(k8sClient.Create(ctx, gwc)).Should(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, gwc)).Should(Succeed())
+			})
+		})
+
 		It("Should not be marked as accepted", func() {
+			nn := types.NamespacedName{Name: gwc.Name}
+			fetched := &gatewayapi.GatewayClass{}
 
-			err := yaml.Unmarshal([]byte(gatewayclassManifestNotOurs), gwcIn)
-			Expect(err).Should(Succeed())
-			Expect(k8sClient.Create(ctx, gwcIn)).Should(Succeed())
-
-			lookupKey := types.NamespacedName{Name: gwcIn.ObjectMeta.Name, Namespace: ""}
-
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, lookupKey, gwc)
-				if err != nil ||
-					gwc.Status.Conditions[0].Status != "Unknown" {
-					return false
+			// Use Eventually here to wait for the controller to process the
+			// newly created GatewayClass that we do not own and check that it
+			// is not marked as accepted. Since the controller should ignore
+			// GatewayClasses that do not specify our controller name, we expect
+			// that either there will be no Accepted condition at all, or if the
+			// controller does set an Accepted condition for some reason, it
+			// will remain in the Unknown state since the controller is not
+			// actively processing it. This test ensures that the controller is
+			// correctly ignoring resources that it does not own.
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, nn, fetched)).To(Succeed())
+				cond := conditionByType(fetched.Status.Conditions, string(gatewayapi.GatewayClassConditionStatusAccepted))
+				// Either no condition at all, or still Unknown
+				if cond != nil {
+					g.Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
 				}
-				return true
-			}, timeout, interval).Should(BeTrue())
-
-			Expect(k8sClient.Delete(ctx, gwcIn)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
 		})
 	})
 })

--- a/controllers/httproute_controller_test.go
+++ b/controllers/httproute_controller_test.go
@@ -1,0 +1,510 @@
+/*
+Copyright 2023 TV 2 DANMARK A/S
+
+Licensed under the Apache License, Version 2.0 (the "License") with the
+following modification to section 6. Trademarks:
+
+Section 6. Trademarks is deleted and replaced by the following wording:
+
+6. Trademarks. This License does not grant permission to use the trademarks and
+trade names of TV 2 DANMARK A/S, including but not limited to the TV 2® logo and
+word mark, except (a) as required for reasonable and customary use in describing
+the origin of the Work, e.g. as described in section 4(c) of the License, and
+(b) to reproduce the content of the NOTICE file. Any reference to the Licensor
+must be made by making a reference to "TV 2 DANMARK A/S", written in capitalized
+letters as in this example, unless the format in which the reference is made,
+requires lower case letters.
+
+You may not use this software except in compliance with the License and the
+modifications set out above.
+
+You may obtain a copy of the license at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gwcapi "github.com/tv2/bifrost-gateway-controller/apis/gateway.tv2.dk/v1alpha1"
+	selfapi "github.com/tv2/bifrost-gateway-controller/pkg/api"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// ------------------------------------
+// [derefCmp] tests
+// ------------------------------------
+
+var _ = Describe("derefCmp", func() {
+
+	It("Should return true when both arguments are nil", func() {
+		Expect(derefCmp[string](nil, nil)).To(BeTrue())
+	})
+
+	It("Should return false when only first argument is nil", func() {
+		b := PtrTo("x")
+		Expect(derefCmp(nil, b)).To(BeFalse())
+	})
+
+	It("Should return false when only second argument is nil", func() {
+		a := PtrTo("x")
+		Expect(derefCmp(a, nil)).To(BeFalse())
+	})
+
+	It("Should return true when both values are equal", func() {
+		Expect(derefCmp(PtrTo(42), PtrTo(42))).To(BeTrue())
+	})
+
+	It("Should return false when both values differ", func() {
+		Expect(derefCmp(PtrTo(1), PtrTo(2))).To(BeFalse())
+	})
+})
+
+// ------------------------------------
+// [parentRefCmp] tests
+// ------------------------------------
+
+var _ = Describe("parentRefCmp", func() {
+
+	// baseRef returns a sample ParentReference with all fields set. We can use
+	// this as a starting point for our tests, and modify individual fields to
+	// test how parentRefCmp handles differences in each field.
+	baseRef := func() gatewayapi.ParentReference {
+		return gatewayapi.ParentReference{
+			Group:       PtrTo(gatewayapi.Group(gatewayapi.GroupName)),
+			Kind:        PtrTo(gatewayapi.Kind("Gateway")),
+			Namespace:   PtrTo(gatewayapi.Namespace("default")),
+			Name:        "my-gw",
+			SectionName: PtrTo(gatewayapi.SectionName("https")),
+			Port:        PtrTo(gatewayapi.PortNumber(443)),
+		}
+	}
+
+	It("Should return true for identical refs", func() {
+		a, b := baseRef(), baseRef()
+		Expect(parentRefCmp(a, b)).To(BeTrue())
+	})
+
+	It("Should return false when names differ", func() {
+		a, b := baseRef(), baseRef()
+		b.Name = "other-gw"
+		Expect(parentRefCmp(a, b)).To(BeFalse())
+	})
+
+	It("Should return false when groups differ", func() {
+		a, b := baseRef(), baseRef()
+		b.Group = PtrTo(gatewayapi.Group("wrong"))
+		Expect(parentRefCmp(a, b)).To(BeFalse())
+	})
+
+	It("Should return false when kinds differ", func() {
+		a, b := baseRef(), baseRef()
+		b.Kind = PtrTo(gatewayapi.Kind("Service"))
+		Expect(parentRefCmp(a, b)).To(BeFalse())
+	})
+
+	It("Should return false when namespaces differ", func() {
+		a, b := baseRef(), baseRef()
+		b.Namespace = PtrTo(gatewayapi.Namespace("other"))
+		Expect(parentRefCmp(a, b)).To(BeFalse())
+	})
+
+	It("Should return false when sectionNames differ", func() {
+		a, b := baseRef(), baseRef()
+		b.SectionName = PtrTo(gatewayapi.SectionName("http"))
+		Expect(parentRefCmp(a, b)).To(BeFalse())
+	})
+
+	It("Should return false when ports differ", func() {
+		a, b := baseRef(), baseRef()
+		b.Port = PtrTo(gatewayapi.PortNumber(80))
+		Expect(parentRefCmp(a, b)).To(BeFalse())
+	})
+
+	It("Should match when both optional fields are nil", func() {
+		a := gatewayapi.ParentReference{Name: "gw"}
+		b := gatewayapi.ParentReference{Name: "gw"}
+		Expect(parentRefCmp(a, b)).To(BeTrue())
+	})
+
+	It("Should not match when one optional field is nil and other is set", func() {
+		a := gatewayapi.ParentReference{Name: "gw"}
+		b := gatewayapi.ParentReference{Name: "gw", Port: PtrTo(gatewayapi.PortNumber(80))}
+		Expect(parentRefCmp(a, b)).To(BeFalse())
+	})
+})
+
+// ------------------------------------
+// [lookupParent] tests
+// ------------------------------------
+
+var _ = Describe("lookupParent", func() {
+
+	It("Should use HTTPRoute namespace when parentRef has no namespace", func() {
+		gw := &gatewayapi.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-gw", Namespace: "route-ns"},
+		}
+		rt := &gatewayapi.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "rt1", Namespace: "route-ns"},
+		}
+		r := newFakeClient(gw)
+		parent := gatewayapi.ParentReference{Name: "my-gw"}
+
+		result, err := lookupParent(context.Background(), r, rt, parent)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Name).To(Equal("my-gw"))
+		Expect(result.Namespace).To(Equal("route-ns"))
+	})
+
+	It("Should use explicit namespace from parentRef", func() {
+		gw := &gatewayapi.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-gw", Namespace: "explicit-ns"},
+		}
+		rt := &gatewayapi.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "rt1", Namespace: "route-ns"},
+		}
+		r := newFakeClient(gw)
+		parent := gatewayapi.ParentReference{
+			Name:      "my-gw",
+			Namespace: PtrTo(gatewayapi.Namespace("explicit-ns")),
+		}
+
+		result, err := lookupParent(context.Background(), r, rt, parent)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Namespace).To(Equal("explicit-ns"))
+	})
+
+	It("Should error when gateway not found", func() {
+		rt := &gatewayapi.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: "rt1", Namespace: "default"},
+		}
+		r := newFakeClient()
+		parent := gatewayapi.ParentReference{Name: "nonexistent"}
+
+		_, err := lookupParent(context.Background(), r, rt, parent)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+// ------------------------------------
+// [findParentRouteStatus] tests
+// ------------------------------------
+
+var _ = Describe("findParentRouteStatus", func() {
+
+	parent := gatewayapi.ParentReference{
+		Kind: PtrTo(gatewayapi.Kind("Gateway")),
+		Name: "my-gw",
+	}
+
+	It("Should return nil when no parents in status", func() {
+		status := &gatewayapi.RouteStatus{}
+		Expect(findParentRouteStatus(status, parent)).To(BeNil())
+	})
+
+	It("Should return nil when parent matches but controller differs", func() {
+		status := &gatewayapi.RouteStatus{
+			Parents: []gatewayapi.RouteParentStatus{{
+				ParentRef:      parent,
+				ControllerName: "other-controller",
+			}},
+		}
+		Expect(findParentRouteStatus(status, parent)).To(BeNil())
+	})
+
+	It("Should return nil when controller matches but parent differs", func() {
+		otherParent := gatewayapi.ParentReference{
+			Kind: PtrTo(gatewayapi.Kind("Gateway")),
+			Name: "other-gw",
+		}
+		status := &gatewayapi.RouteStatus{
+			Parents: []gatewayapi.RouteParentStatus{{
+				ParentRef:      otherParent,
+				ControllerName: selfapi.SelfControllerName,
+			}},
+		}
+		Expect(findParentRouteStatus(status, parent)).To(BeNil())
+	})
+
+	It("Should return matching entry", func() {
+		status := &gatewayapi.RouteStatus{
+			Parents: []gatewayapi.RouteParentStatus{{
+				ParentRef:      parent,
+				ControllerName: selfapi.SelfControllerName,
+				Conditions: []metav1.Condition{{
+					Type:   "Accepted",
+					Status: metav1.ConditionTrue,
+				}},
+			}},
+		}
+		result := findParentRouteStatus(status, parent)
+		Expect(result).NotTo(BeNil())
+		Expect(result.Conditions[0].Type).To(Equal("Accepted"))
+	})
+})
+
+// ------------------------------------
+// [setRouteStatusCondition] tests
+// ------------------------------------
+
+var _ = Describe("setRouteStatusCondition", func() {
+
+	parent := gatewayapi.ParentReference{
+		Kind: PtrTo(gatewayapi.Kind("Gateway")),
+		Name: "my-gw",
+	}
+
+	It("Should append new parent status when none exists", func() {
+		status := &gatewayapi.RouteStatus{}
+		setRouteStatusCondition(status, parent, &metav1.Condition{
+			Type:   "Accepted",
+			Status: metav1.ConditionTrue,
+			Reason: "Accepted",
+		})
+
+		Expect(status.Parents[0].ControllerName).To(Equal(selfapi.SelfControllerName))
+		Expect(status.Parents[0].Conditions[0].Type).To(Equal("Accepted"))
+		Expect(status.Parents[0].Conditions[0].LastTransitionTime.IsZero()).To(BeFalse())
+	})
+
+	It("Should update existing condition for same parent", func() {
+		status := &gatewayapi.RouteStatus{
+			Parents: []gatewayapi.RouteParentStatus{{
+				ParentRef:      parent,
+				ControllerName: selfapi.SelfControllerName,
+				Conditions: []metav1.Condition{{
+					Type:   "Accepted",
+					Status: metav1.ConditionFalse,
+					Reason: "Pending",
+				}},
+			}},
+		}
+		setRouteStatusCondition(status, parent, &metav1.Condition{
+			Type:   "Accepted",
+			Status: metav1.ConditionTrue,
+			Reason: "Accepted",
+		})
+
+		Expect(status.Parents[0].Conditions[0].Status).To(Equal(metav1.ConditionTrue))
+	})
+
+	It("Should add condition for different parent without affecting existing", func() {
+		otherParent := gatewayapi.ParentReference{
+			Kind: PtrTo(gatewayapi.Kind("Gateway")),
+			Name: "other-gw",
+		}
+		status := &gatewayapi.RouteStatus{
+			Parents: []gatewayapi.RouteParentStatus{{
+				ParentRef:      otherParent,
+				ControllerName: selfapi.SelfControllerName,
+				Conditions: []metav1.Condition{{
+					Type:   "Accepted",
+					Status: metav1.ConditionTrue,
+					Reason: "Accepted",
+				}},
+			}},
+		}
+		setRouteStatusCondition(status, parent, &metav1.Condition{
+			Type:   "Accepted",
+			Status: metav1.ConditionTrue,
+			Reason: "Accepted",
+		})
+
+		Expect(status.Parents).To(HaveLen(2))
+	})
+
+	It("Should preserve provided LastTransitionTime", func() {
+		status := &gatewayapi.RouteStatus{}
+		fixedTime := metav1.NewTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+		setRouteStatusCondition(status, parent, &metav1.Condition{
+			Type:               "Accepted",
+			Status:             metav1.ConditionTrue,
+			Reason:             "Accepted",
+			LastTransitionTime: fixedTime,
+		})
+
+		Expect(status.Parents[0].Conditions[0].LastTransitionTime).To(Equal(fixedTime))
+	})
+})
+
+// ====================================================================
+// Integration tests
+// ====================================================================
+
+var _ = Describe("HTTPRoute controller", func() {
+
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	var (
+		gwc  *gatewayapi.GatewayClass
+		gwcb *gwcapi.GatewayClassBlueprint
+		gw   *gatewayapi.Gateway
+		ctx  context.Context
+	)
+
+	BeforeEach(func() {
+		// Before each test, we create a GatewayClass and Gateway that the
+		// HTTPRoute will reference. This setup is necessary for the HTTPRoute
+		// controller to process the route and update its status based on the
+		// parent gateway's status.
+		ctx = context.Background()
+		gwc = newTestGatewayClass()
+		Expect(k8sClient.Create(ctx, gwc)).Should(Succeed())
+		gwcb = newTestBlueprint()
+		Expect(k8sClient.Create(ctx, gwcb)).Should(Succeed())
+		gw = newTestGateway()
+		Expect(k8sClient.Create(ctx, gw)).Should(Succeed())
+		DeferCleanup(func() { // Clean up the created resources after each test to ensure isolation between tests
+			Expect(k8sClient.Delete(ctx, gw)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, gwcb)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, gwc)).Should(Succeed())
+		})
+	})
+
+	When("An HTTPRoute targeting our Gateway is created", func() {
+		var rt *gatewayapi.HTTPRoute
+
+		// Before each test in this block, we create an HTTPRoute that
+		// references the Gateway we set up in the outer BeforeEach. This allows
+		// us to test how the HTTPRoute controller processes a route that
+		// targets a gateway it manages, and how it updates the route's status
+		// based on the parent gateway's status.
+		BeforeEach(func() {
+			gwKind := gatewayapi.Kind("Gateway")
+			gwGroup := gatewayapi.Group(gatewayapi.GroupName)
+			gwNs := gatewayapi.Namespace(gw.Namespace)
+			rt = &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "default",
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{{
+							Group:     &gwGroup,
+							Kind:      &gwKind,
+							Name:      gatewayapi.ObjectName(gw.Name),
+							Namespace: &gwNs,
+						}},
+					},
+					Rules: []gatewayapi.HTTPRouteRule{{
+						BackendRefs: []gatewayapi.HTTPBackendRef{{
+							BackendRef: gatewayapi.BackendRef{
+								BackendObjectReference: gatewayapi.BackendObjectReference{
+									Name: "my-service",
+									Port: PtrTo(gatewayapi.PortNumber(8080)),
+								},
+							},
+						}},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, rt)).Should(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, rt)).Should(Succeed())
+			})
+		})
+
+		It("Should set Accepted=true status for the parent gateway", func() {
+			nn := types.NamespacedName{Name: rt.Name, Namespace: rt.Namespace}
+			fetched := &gatewayapi.HTTPRoute{}
+
+			// Use Eventually here to wait for the controller to process the
+			// newly created HTTPRoute and update its status with the parent
+			// status indicating that it is accepted by the gateway. This is
+			// necessary because the controller processes resources
+			// asynchronously.
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, nn, fetched)).To(Succeed())
+				g.Expect(fetched.Status.Parents).NotTo(BeEmpty())
+				found := false
+				for _, ps := range fetched.Status.Parents {
+					if ps.ControllerName == selfapi.SelfControllerName &&
+						ps.ParentRef.Name == gatewayapi.ObjectName(gw.Name) {
+						cond := conditionByType(ps.Conditions, string(gatewayapi.RouteConditionAccepted))
+						g.Expect(cond).NotTo(BeNil())
+						g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+						found = true
+					}
+				}
+				g.Expect(found).To(BeTrue(), "expected parent status for our controller")
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("Should create shadow HTTPRoute from blueprint template", func() {
+			shadowNN := types.NamespacedName{
+				Name:      rt.Name + "-istio",
+				Namespace: rt.Namespace,
+			}
+			shadowRT := &gatewayapi.HTTPRoute{}
+
+			// Use Eventually here to wait for the controller to process the
+			// newly created HTTPRoute and create the corresponding shadow route
+			// based on the blueprint template. This is necessary because the
+			// controller processes resources asynchronously.
+			Eventually(func() error {
+				return k8sClient.Get(ctx, shadowNN, shadowRT)
+			}, timeout, interval).Should(Succeed())
+
+			// Verify the shadow route's parentRef points to the shadow gateway
+			Expect(shadowRT.Spec.ParentRefs).NotTo(BeEmpty())
+		})
+	})
+
+	When("An HTTPRoute targets a non-Gateway kind", func() {
+		It("Should not set any parent status for that ref", func() {
+			svcKind := gatewayapi.Kind("Service")
+			rt := &gatewayapi.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "svc-route",
+					Namespace: "default",
+				},
+				Spec: gatewayapi.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapi.CommonRouteSpec{
+						ParentRefs: []gatewayapi.ParentReference{{
+							Kind: &svcKind,
+							Name: "some-service",
+						}},
+					},
+				},
+			}
+			// Expect the route to be created successfully, but since the
+			// controller only processes parentRefs that point to Gateways, it
+			// should not set any status for this route.
+			Expect(k8sClient.Create(ctx, rt)).Should(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, rt)).Should(Succeed())
+			})
+
+			nn := types.NamespacedName{Name: rt.Name, Namespace: rt.Namespace}
+			fetched := &gatewayapi.HTTPRoute{}
+
+			// Give the controller time to process, then verify no status was
+			// set. We use Consistently here to check that the status remains
+			// unchanged over a period of time, confirming that the controller
+			// is not updating it.
+			Consistently(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, nn, fetched)).To(Succeed())
+				for _, ps := range fetched.Status.Parents {
+					g.Expect(ps.ControllerName).NotTo(Equal(selfapi.SelfControllerName))
+				}
+			}, 3*time.Second, interval).Should(Succeed())
+		})
+	})
+})

--- a/controllers/statuscheck_test.go
+++ b/controllers/statuscheck_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2023 TV 2 DANMARK A/S
+
+Licensed under the Apache License, Version 2.0 (the "License") with the
+following modification to section 6. Trademarks:
+
+Section 6. Trademarks is deleted and replaced by the following wording:
+
+6. Trademarks. This License does not grant permission to use the trademarks and
+trade names of TV 2 DANMARK A/S, including but not limited to the TV 2® logo and
+word mark, except (a) as required for reasonable and customary use in describing
+the origin of the Work, e.g. as described in section 4(c) of the License, and
+(b) to reproduce the content of the NOTICE file. Any reference to the Licensor
+must be made by making a reference to "TV 2 DANMARK A/S", written in capitalized
+letters as in this example, unless the format in which the reference is made,
+requires lower case letters.
+
+You may not use this software except in compliance with the License and the
+modifications set out above.
+
+You may obtain a copy of the license at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ------------------------------------
+// [statusIsReady] tests
+// ------------------------------------
+
+var _ = Describe("statusIsReady", func() {
+
+	It("Should return true for empty templates", func() {
+		ready, err := statusIsReady(nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ready).To(BeTrue())
+	})
+
+	It("Should return false when a resource has no Current", func() {
+		templates := []*ResourceTemplateState{
+			{Resources: []ResourceComposite{{Current: nil}}},
+		}
+		ready, err := statusIsReady(templates)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ready).To(BeFalse())
+	})
+
+	It("Should return false when a resource is not ready", func() {
+		u := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]any{"name": "dep1", "generation": int64(2)},
+			"status": map[string]any{
+				"observedGeneration": int64(1),
+				"conditions": []any{
+					map[string]any{
+						"type":   "Available",
+						"status": "False",
+						"reason": "MinimumReplicasUnavailable",
+					},
+				},
+			},
+		}}
+		templates := []*ResourceTemplateState{
+			{Resources: []ResourceComposite{{Current: u}}},
+		}
+		ready, err := statusIsReady(templates)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ready).To(BeFalse())
+	})
+
+	It("Should return true when all resources have Current with ready status", func() {
+		u := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "cm1", "generation": int64(1)},
+		}}
+		templates := []*ResourceTemplateState{
+			{Resources: []ResourceComposite{{Current: u}}},
+		}
+		ready, err := statusIsReady(templates)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ready).To(BeTrue())
+	})
+})
+
+// ------------------------------------
+// [statusExistingTemplates] tests
+// ------------------------------------
+
+var _ = Describe("statusExistingTemplates", func() {
+
+	It("Should return empty for all-existing resources", func() {
+		u := &unstructured.Unstructured{Object: map[string]any{"metadata": map[string]any{"name": "x"}}}
+		templates := []*ResourceTemplateState{
+			{TemplateName: "t1", Resources: []ResourceComposite{{Current: u}}},
+		}
+		missing := statusExistingTemplates(templates)
+		Expect(missing).To(BeEmpty())
+	})
+
+	It("Should report template name with [] when no resources rendered", func() {
+		templates := []*ResourceTemplateState{
+			{TemplateName: "configMapTest"},
+		}
+		missing := statusExistingTemplates(templates)
+		Expect(missing).To(ConsistOf("configMapTest[]"))
+	})
+
+	It("Should report template name with index for missing Current", func() {
+		templates := []*ResourceTemplateState{
+			{TemplateName: "multiResource", Resources: []ResourceComposite{
+				{Current: &unstructured.Unstructured{Object: map[string]any{"metadata": map[string]any{"name": "x"}}}},
+				{Current: nil},
+			}},
+		}
+		missing := statusExistingTemplates(templates)
+		Expect(missing).To(ConsistOf("multiResource[1]"))
+	})
+
+	It("Should report multiple missing across templates", func() {
+		templates := []*ResourceTemplateState{
+			{TemplateName: "a", Resources: []ResourceComposite{{Current: nil}}},
+			{TemplateName: "b"},
+		}
+		missing := statusExistingTemplates(templates)
+		Expect(missing).To(ConsistOf("a[0]", "b[]"))
+	})
+})

--- a/controllers/templating_test.go
+++ b/controllers/templating_test.go
@@ -197,7 +197,7 @@ var _ = Describe("renderTemplates", func() {
 			{TemplateName: "bad", Template: badTmpl, StringTemplate: "val: {{ .Values.missing }}"},
 		}
 		rendered, exists := renderTemplates(ctx, r, newTestParentGateway(), templates, &TemplateValues{}, false)
-		Expect(rendered).To(Equal(1)) // TODO: seems wierd that rendered and exists always equal the same.
+		Expect(rendered).To(Equal(1)) // TODO: seems weird that rendered and exists always equal the same.
 		Expect(exists).To(Equal(1))
 	})
 })
@@ -220,8 +220,11 @@ var _ = Describe("buildResourceValues", func() {
 		}
 		vals := buildResourceValues(templates)
 		Expect(vals).To(HaveKey("myResource"))
-		resources := vals["myResource"].([]map[string]any)
-		Expect(resources[0]["data"].(map[string]any)["key"]).To(Equal("val"))
+		resources, ok := vals["myResource"].([]map[string]any)
+		Expect(ok).To(BeTrue())
+		data, ok := resources[0]["data"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(data["key"]).To(Equal("val"))
 	})
 
 	It("Should return empty map entries for resources without Current", func() {
@@ -230,7 +233,8 @@ var _ = Describe("buildResourceValues", func() {
 		}
 		vals := buildResourceValues(templates)
 		Expect(vals).To(HaveKey("pending"))
-		resources := vals["pending"].([]map[string]any)
+		resources, ok := vals["pending"].([]map[string]any)
+		Expect(ok).To(BeTrue())
 		Expect(resources).To(HaveLen(0))
 	})
 
@@ -472,10 +476,12 @@ var _ = Describe("objectToMap", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(m).To(HaveKey("metadata"))
 		Expect(m).To(HaveKey("spec"))
-		metadata := m["metadata"].(map[string]any)
+		metadata, ok := m["metadata"].(map[string]any)
+		Expect(ok).To(BeTrue())
 		Expect(metadata["name"]).To(Equal("test-gw"))
 		Expect(metadata["namespace"]).To(Equal("default"))
-		spec := m["spec"].(map[string]any)
+		spec, ok := m["spec"].(map[string]any)
+		Expect(ok).To(BeTrue())
 		Expect(spec["gatewayClassName"]).To(Equal("my-class"))
 	})
 

--- a/controllers/templating_test.go
+++ b/controllers/templating_test.go
@@ -1,103 +1,492 @@
+/*
+Copyright 2023 TV 2 DANMARK A/S
+
+Licensed under the Apache License, Version 2.0 (the "License") with the
+following modification to section 6. Trademarks:
+
+Section 6. Trademarks is deleted and replaced by the following wording:
+
+6. Trademarks. This License does not grant permission to use the trademarks and
+trade names of TV 2 DANMARK A/S, including but not limited to the TV 2® logo and
+word mark, except (a) as required for reasonable and customary use in describing
+the origin of the Work, e.g. as described in section 4(c) of the License, and
+(b) to reproduce the content of the NOTICE file. Any reference to the Licensor
+must be made by making a reference to "TV 2 DANMARK A/S", written in capitalized
+letters as in this example, unless the format in which the reference is made,
+requires lower case letters.
+
+You may not use this software except in compliance with the License and the
+modifications set out above.
+
+You may obtain a copy of the license at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controllers
 
 import (
-	"testing"
+	"context"
 
-	"k8s.io/apimachinery/pkg/util/yaml"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func TestParseSingleTemplate(t *testing.T) {
-	template := "foo"
-	tmpl, err := parseSingleTemplate("foo", template)
-	if tmpl == nil || err != nil {
-		t.Fatalf("Error parsing template %v", err)
+// ------------------------------------
+// Test Helpers
+// ------------------------------------
+
+// newTestParentGateway returns a Gateway suitable for use as a parent in templating tests
+func newTestParentGateway() *gatewayapi.Gateway {
+	return &gatewayapi.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "parent-gw",
+			Namespace: "default",
+			UID:       types.UID("parent-uid"),
+		},
 	}
 }
 
-var textTemplate = `
-t1: |
-    name: {{ .Values.name1 }}
-t2: |
-    {{ if .Values.t2enable }}
-    name: {{ .Values.name2 }}
-    {{ end }}
-t3: |
-    {{ range $idx,$data := .Values.t3data }}
-    name: {{ $.Values.name3 }}-{{ $data }}-{{ $idx }}
-    ---
-    {{ end }}
-`
+// ------------------------------------
+// [parseSingleTemplate] tests
+// ------------------------------------
 
-var textValues = `
-name1: t1name
-name2: t2name
-name3: t3name
-t2enable: false
-t3data:
-- foo1
-- foo2
-- foo3
-`
+var _ = Describe("parseSingleTemplate", func() {
 
-func helperGetResourceState() ([]*ResourceTemplateState, error) {
-	templates := map[string]string{}
-	_ = yaml.Unmarshal([]byte(textTemplate), &templates)
-	return parseTemplates(templates)
-}
+	It("Should parse a valid template with custom helpers", func() {
+		tmpl, err := parseSingleTemplate("test", `{{ toYaml .Values | nindent 2 }}`)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tmpl).NotTo(BeNil())
+	})
 
-func helperGetValues() *TemplateValues {
-	values := map[string]any{}
-	_ = yaml.Unmarshal([]byte(textValues), &values)
-	templateValues := TemplateValues{
-		Values: values,
-	}
-	return &templateValues
-}
+	It("Should return error for invalid template syntax", func() {
+		_, err := parseSingleTemplate("test", "key: {{ .Values.foo }")
+		Expect(err).To(HaveOccurred())
+	})
+})
 
-func TestParseTemplate(t *testing.T) {
-	tmpl, err := helperGetResourceState()
-	if tmpl == nil || err != nil {
-		t.Fatalf("Error parsing templates %v", err)
-	}
-	if len(tmpl) != 3 {
-		t.Fatalf("Template slice length mismatch, got %v, expected 3", len(tmpl))
-	}
-	if tmpl[0].TemplateName != "t1" {
-		t.Fatalf("Template[0] name, got %v, expected t1", tmpl[0].TemplateName)
-	}
-}
+// ------------------------------------
+// [parseTemplates] tests
+// ------------------------------------
 
-func TestTemplate2map(t *testing.T) {
-	tmpl, err := helperGetResourceState()
-	if err != nil {
-		t.Fatalf("Cannot get resource state: %v", err)
+var _ = Describe("parseTemplates", func() {
+
+	It("Should parse a map of templates", func() {
+		templates, err := parseTemplates(map[string]string{
+			"resource1": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm1",
+			"resource2": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm2",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(templates[0].TemplateName).To(Equal("resource1"))
+		Expect(templates[0].StringTemplate).To(ContainSubstring("name: cm1"))
+		Expect(templates[0].Template).NotTo(BeNil())
+		Expect(templates[1].TemplateName).To(Equal("resource2"))
+		Expect(templates[1].StringTemplate).To(ContainSubstring("name: cm2"))
+		Expect(templates[1].Template).NotTo(BeNil())
+	})
+
+	It("Should sort templates alphabetically by key", func() {
+		templates, err := parseTemplates(map[string]string{
+			"cResource": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: c",
+			"aResource": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: a",
+			"bResource": "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: b",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(templates[0].TemplateName).To(Equal("aResource"))
+		Expect(templates[1].TemplateName).To(Equal("bResource"))
+		Expect(templates[2].TemplateName).To(Equal("cResource"))
+	})
+
+	It("Should return error for invalid template in the map", func() {
+		_, err := parseTemplates(map[string]string{
+			"bad": "{{ .Values.foo }",
+		})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Should handle empty map", func() {
+		templates, err := parseTemplates(map[string]string{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(templates).To(BeEmpty())
+	})
+})
+
+// ------------------------------------
+// [renderTemplates] tests
+// ------------------------------------
+
+var _ = Describe("renderTemplates", func() {
+	var (
+		ctx   = context.Background()
+		cmGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+	)
+
+	It("Should render a template and count it", func() {
+		r := newFakeDynClient()
+		tmpl, err := parseSingleTemplate("t1", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm1")
+		Expect(err).NotTo(HaveOccurred())
+		// Pre-populate Resources to skip template2Composite (which needs a REST mapper)
+		templates := []*ResourceTemplateState{
+			{
+				TemplateName:   "t1",
+				Template:       tmpl,
+				StringTemplate: "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm1",
+				Resources: []ResourceComposite{
+					{
+						Rendered:     &unstructured.Unstructured{Object: map[string]any{"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "cm1"}}},
+						GVR:          &cmGVR,
+						IsNamespaced: true,
+					},
+				},
+			},
+		}
+		rendered, exists := renderTemplates(ctx, r, newTestParentGateway(), templates, &TemplateValues{}, false)
+		Expect(rendered).To(Equal(1))
+		Expect(exists).To(Equal(1))
+	})
+
+	It("Should skip already rendered templates", func() {
+		r := newFakeDynClient()
+		current := &unstructured.Unstructured{Object: map[string]any{"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "cm1"}}}
+		templates := []*ResourceTemplateState{
+			{
+				TemplateName: "t1",
+				Resources: []ResourceComposite{
+					{
+						Rendered:     &unstructured.Unstructured{Object: map[string]any{"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "cm1"}}},
+						GVR:          &cmGVR,
+						IsNamespaced: true,
+						Current:      current,
+					},
+				},
+			},
+		}
+		rendered, exists := renderTemplates(ctx, r, newTestParentGateway(), templates, &TemplateValues{}, false)
+		Expect(rendered).To(Equal(1))
+		Expect(exists).To(Equal(1))
+		// Current should remain unchanged (not re-fetched)
+		Expect(templates[0].Resources[0].Current).To(Equal(current))
+	})
+
+	It("Should count rendered and exists independently", func() {
+		r := newFakeDynClient()
+		current := &unstructured.Unstructured{Object: map[string]any{"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "cm1"}}}
+		badTmpl, err := parseSingleTemplate("bad", "val: {{ .Values.missing }}")
+		Expect(err).NotTo(HaveOccurred())
+		templates := []*ResourceTemplateState{
+			// This one has resources and current — should count as rendered + exists
+			{
+				TemplateName: "good",
+				Resources: []ResourceComposite{
+					{Rendered: &unstructured.Unstructured{Object: map[string]any{"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "cm1"}}},
+						GVR: &cmGVR, IsNamespaced: true, Current: current},
+				},
+			},
+			// This one fails to render — should not count
+			{TemplateName: "bad", Template: badTmpl, StringTemplate: "val: {{ .Values.missing }}"},
+		}
+		rendered, exists := renderTemplates(ctx, r, newTestParentGateway(), templates, &TemplateValues{}, false)
+		Expect(rendered).To(Equal(1)) // TODO: seems wierd that rendered and exists always equal the same.
+		Expect(exists).To(Equal(1))
+	})
+})
+
+// ------------------------------------
+// [buildResourceValues] tests
+// ------------------------------------
+
+var _ = Describe("buildResourceValues", func() {
+
+	It("Should build map from template resource list", func() {
+		u := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "cm1"},
+			"data":       map[string]any{"key": "val"},
+		}}
+		templates := []*ResourceTemplateState{
+			{TemplateName: "myResource", Resources: []ResourceComposite{{Current: u}}},
+		}
+		vals := buildResourceValues(templates)
+		Expect(vals).To(HaveKey("myResource"))
+		resources := vals["myResource"].([]map[string]any)
+		Expect(resources[0]["data"].(map[string]any)["key"]).To(Equal("val"))
+	})
+
+	It("Should return empty map entries for resources without Current", func() {
+		templates := []*ResourceTemplateState{
+			{TemplateName: "pending", Resources: []ResourceComposite{{Current: nil}}},
+		}
+		vals := buildResourceValues(templates)
+		Expect(vals).To(HaveKey("pending"))
+		resources := vals["pending"].([]map[string]any)
+		Expect(resources).To(HaveLen(0))
+	})
+
+	It("Should handle templates with no resources", func() {
+		templates := []*ResourceTemplateState{
+			{TemplateName: "empty"},
+		}
+		vals := buildResourceValues(templates)
+		Expect(vals).To(HaveKey("empty"))
+	})
+})
+
+// ------------------------------------
+// [applyTemplates] tests
+// ------------------------------------
+
+var _ = Describe("applyTemplates", func() {
+	var (
+		ctx    = context.Background()
+		cmGVR  = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+		crdGVR = schema.GroupVersionResource{Group: "example.io", Version: "v1", Resource: "widgets"}
+	)
+
+	newRendered := func(name string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": name, "namespace": "default"},
+		}}
 	}
-	tmplValues := helperGetValues()
-	rawResources, err := template2maps(tmpl[0].Template, tmplValues)
-	if rawResources == nil || err != nil {
-		t.Fatalf("Cannot render template to map: %v", err)
-	}
-	if len(rawResources) != 1 {
-		t.Fatalf("Error rendering resource, got len %v, expected 1", len(rawResources))
-	}
-	if rawResources[0]["name"] != "t1name" {
-		t.Fatalf("Rendered template error, got %v, expected 't1name'", rawResources[0]["name"])
-	}
-	rawResources, err = template2maps(tmpl[1].Template, tmplValues)
-	if err != nil {
-		t.Fatalf("Error rendering empty resource, got err %v", err)
-	}
-	if len(rawResources) != 0 {
-		t.Fatalf("Error rendering empty resource, got len %v, expected 0", len(rawResources))
-	}
-	rawResources, err = template2maps(tmpl[2].Template, tmplValues)
-	if err != nil {
-		t.Fatalf("Error rendering multi-resource, got err %v", err)
-	}
-	if len(rawResources) != 3 {
-		t.Fatalf("Error rendering multi-resource, got len %v, expected 3", len(rawResources))
-	}
-	if rawResources[2]["name"] != "t3name-foo3-2" {
-		t.Fatalf("Rendered template error, got %v, expected 't3name-foo3-2'", rawResources[2]["name"])
-	}
-}
+
+	It("Should skip resources with nil Rendered", func() {
+		r := newFakeDynClient()
+		templates := []*ResourceTemplateState{
+			{TemplateName: "t1", Resources: []ResourceComposite{
+				{Rendered: nil, GVR: &cmGVR, IsNamespaced: true},
+			}},
+		}
+		err := applyTemplates(ctx, r, newTestParentGateway(), templates)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Should skip resources with nil GVR", func() {
+		r := newFakeDynClient()
+		templates := []*ResourceTemplateState{
+			{TemplateName: "t1", Resources: []ResourceComposite{
+				{Rendered: newRendered("cm1"), GVR: nil, IsNamespaced: true},
+			}},
+		}
+		err := applyTemplates(ctx, r, newTestParentGateway(), templates)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Should apply namespaced resource with owner reference", func() {
+		r := newFakeDynClient()
+		templates := []*ResourceTemplateState{
+			{TemplateName: "t1", Resources: []ResourceComposite{
+				{Rendered: newRendered("cm1"), GVR: &cmGVR, IsNamespaced: true},
+			}},
+		}
+		err := applyTemplates(ctx, r, newTestParentGateway(), templates)
+		Expect(err).NotTo(HaveOccurred())
+		// Verify owner reference was set on the rendered resource
+		ownerRefs := templates[0].Resources[0].Rendered.GetOwnerReferences()
+		Expect(ownerRefs[0].UID).To(Equal(types.UID("parent-uid")))
+	})
+
+	It("Should apply cluster-scoped resource without owner reference", func() {
+		r := newFakeDynClient()
+		rendered := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "example.io/v1",
+			"kind":       "Widget",
+			"metadata":   map[string]any{"name": "my-widget"},
+		}}
+		templates := []*ResourceTemplateState{
+			{TemplateName: "t1", Resources: []ResourceComposite{
+				{Rendered: rendered, GVR: &crdGVR, IsNamespaced: false},
+			}},
+		}
+		err := applyTemplates(ctx, r, newTestParentGateway(), templates)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rendered.GetOwnerReferences()).To(BeEmpty())
+	})
+
+	It("Should return error when SetControllerReference fails", func() {
+		r := newFakeDynClient()
+		parent := &metav1.ObjectMeta{
+			Name:      "no-uid-gw",
+			Namespace: "default",
+		}
+		templates := []*ResourceTemplateState{
+			{TemplateName: "t1", Resources: []ResourceComposite{
+				{Rendered: newRendered("cm1"), GVR: &cmGVR, IsNamespaced: true},
+			}},
+		}
+		err := applyTemplates(ctx, r, parent, templates)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("found 1 problems while applying 1 templates"))
+	})
+
+	It("Should aggregate errors across multiple templates", func() {
+		r := newFakeDynClient()
+		parent := &metav1.ObjectMeta{Name: "no-uid", Namespace: "default"}
+		templates := []*ResourceTemplateState{
+			{TemplateName: "t1", Resources: []ResourceComposite{
+				{Rendered: newRendered("cm1"), GVR: &cmGVR, IsNamespaced: true},
+			}},
+			{TemplateName: "t2", Resources: []ResourceComposite{
+				{Rendered: newRendered("cm2"), GVR: &cmGVR, IsNamespaced: true},
+			}},
+		}
+		err := applyTemplates(ctx, r, parent, templates)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("found 2 problems while applying 2 templates"))
+	})
+})
+
+// ------------------------------------
+// [helperToYaml] tests
+// ------------------------------------
+
+var _ = Describe("helperToYaml", func() {
+
+	It("Should marshal a simple map to YAML", func() {
+		result := helperToYaml(map[string]any{"key": "value"})
+		Expect(result).To(ContainSubstring("key: value"))
+	})
+
+	It("Should marshal a list", func() {
+		result := helperToYaml([]string{"a", "b"})
+		Expect(result).To(ContainSubstring("- a"))
+		Expect(result).To(ContainSubstring("- b"))
+	})
+
+	It("Should handle nil", func() {
+		result := helperToYaml(nil)
+		Expect(result).To(Equal("null"))
+	})
+})
+
+// ------------------------------------
+// [template2maps] tests
+// ------------------------------------
+
+var _ = Describe("template2maps", func() {
+
+	It("Should render a single document", func() {
+		tmpl, err := parseSingleTemplate("test", "key1: val1\nkey2: val2")
+		Expect(err).NotTo(HaveOccurred())
+		values := &TemplateValues{}
+		maps, err := template2maps(tmpl, values)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(maps[0]["key1"]).To(Equal("val1"))
+		Expect(maps[0]["key2"]).To(Equal("val2"))
+	})
+
+	It("Should render multiple documents", func() {
+		tmpl, err := parseSingleTemplate("test", "name: doc1\n---\nname: doc2\n---\nname: doc3")
+		Expect(err).NotTo(HaveOccurred())
+		values := &TemplateValues{}
+		maps, err := template2maps(tmpl, values)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(maps[0]["name"]).To(Equal("doc1"))
+		Expect(maps[1]["name"]).To(Equal("doc2"))
+		Expect(maps[2]["name"]).To(Equal("doc3"))
+	})
+
+	It("Should use template values in rendering", func() {
+		tmpl, err := parseSingleTemplate("test", "val: {{ .Values.myKey }}")
+		Expect(err).NotTo(HaveOccurred())
+		values := &TemplateValues{Values: map[string]any{"myKey": "hello"}}
+		maps, err := template2maps(tmpl, values)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(maps[0]["val"]).To(Equal("hello"))
+	})
+})
+
+// ------------------------------------
+// [template2Composite] tests
+// ------------------------------------
+
+var _ = Describe("template2Composite", func() {
+
+	It("Should convert a single-document template into a ResourceComposite", func() {
+		r := newFakeClientWithMapper()
+		tmpl, err := parseSingleTemplate("test", "apiVersion: gateway.networking.k8s.io/v1\nkind: Gateway\nmetadata:\n  name: my-gw")
+		Expect(err).NotTo(HaveOccurred())
+		composites, err := template2Composite(r, tmpl, &TemplateValues{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(composites[0].Rendered.GetName()).To(Equal("my-gw"))
+		Expect(composites[0].Rendered.GetKind()).To(Equal("Gateway"))
+		Expect(composites[0].GVR).NotTo(BeNil())
+		Expect(composites[0].GVR.Resource).To(Equal("gateways"))
+		Expect(composites[0].IsNamespaced).To(BeTrue())
+	})
+
+	It("Should convert a multi-document template into multiple ResourceComposites", func() {
+		r := newFakeClientWithMapper()
+		tmpl, err := parseSingleTemplate("test",
+			"apiVersion: gateway.networking.k8s.io/v1\nkind: Gateway\nmetadata:\n  name: gw1\n---\napiVersion: gateway.networking.k8s.io/v1\nkind: Gateway\nmetadata:\n  name: gw2")
+		Expect(err).NotTo(HaveOccurred())
+		composites, err := template2Composite(r, tmpl, &TemplateValues{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(composites[0].Rendered.GetName()).To(Equal("gw1"))
+		Expect(composites[1].Rendered.GetName()).To(Equal("gw2"))
+	})
+
+	It("Should return error when template rendering fails", func() {
+		r := newFakeClientWithMapper()
+		tmpl, err := parseSingleTemplate("test", "val: {{ .Values.missing }}")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = template2Composite(r, tmpl, &TemplateValues{})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("Should return error when GVR lookup fails for unknown kind", func() {
+		r := newFakeClientWithMapper()
+		tmpl, err := parseSingleTemplate("test", "apiVersion: unknown.io/v1\nkind: NoSuchKind\nmetadata:\n  name: x")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = template2Composite(r, tmpl, &TemplateValues{})
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+// ------------------------------------
+// [objectToMap] tests
+// ------------------------------------
+
+var _ = Describe("objectToMap", func() {
+
+	It("Should convert a Gateway to a map", func() {
+		gw := &gatewayapi.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-gw", Namespace: "default"},
+			Spec: gatewayapi.GatewaySpec{
+				GatewayClassName: "my-class",
+			},
+		}
+		m, err := objectToMap(gw)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m).To(HaveKey("metadata"))
+		Expect(m).To(HaveKey("spec"))
+		metadata := m["metadata"].(map[string]any)
+		Expect(metadata["name"]).To(Equal("test-gw"))
+		Expect(metadata["namespace"]).To(Equal("default"))
+		spec := m["spec"].(map[string]any)
+		Expect(spec["gatewayClassName"]).To(Equal("my-class"))
+	})
+
+	It("Should handle unstructured object", func() {
+		u := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "cm1"},
+		}}
+		m, err := objectToMap(u)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m["kind"]).To(Equal("ConfigMap"))
+	})
+})


### PR DESCRIPTION
**Description**

DCP-267: Expand test coverage across the controller package by adding new tests and improving existing ones. AI was used to assist with writing and reviewing tests.

Current test coverage: 90.8%