### PR TITLE
DCP-290: Fix linter issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,15 +65,6 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
-    rules:
-      - linters: [staticcheck]
-        text: "QF1004|QF1007|QF1008"
-      - linters: [staticcheck]
-        text: "SA1019"
-        path: controllers/gateway_controller\.go
-      - linters: [gocritic]
-        text: "importShadow"
-        path: controllers/gatewayclass_controller\.go
     paths:
       - test
       - third_party$

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -304,10 +304,7 @@ func unstructuredToGVR(r ControllerClient, u *unstructured.Unstructured) (*schem
 		return nil, false, fmt.Errorf("cannot find REST mapping for '%s/%s' (group='%s', version='%s'): %w", u.GetKind(), u.GetName(), gv.Group, gv.Version, err)
 	}
 
-	isNamespaced := false
-	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
-		isNamespaced = true
-	}
+	isNamespaced := mapping.Scope.Name() == meta.RESTScopeNameNamespace
 
 	return &schema.GroupVersionResource{
 		Group:    gv.Group,

--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -127,7 +127,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	gwcb, err := lookupGatewayClassBlueprint(ctx, r, gwc)
 	if err != nil {
 		logger.Info("blueprint not found for GatewayClass, requeuing", "gatewayClass", gwc.Name, "parametersRef", gwc.Spec.ParametersRef)
-		return ctrl.Result{RequeueAfter: dependencyMissingRequeuePeriod}, fmt.Errorf("parameters for GatewayClass %q not found: %w", gwc.ObjectMeta.Name, err)
+		return ctrl.Result{RequeueAfter: dependencyMissingRequeuePeriod}, fmt.Errorf("parameters for GatewayClass %q not found: %w", gwc.Name, err)
 	}
 
 	debugContext = append(debugContext, "blueprint", gwcb.Name)
@@ -148,7 +148,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, fmt.Errorf("cannot convert gateway to map: %w", err)
 	}
 
-	values, err := lookupValues(ctx, r, gwc.Name, gwcb, gw.ObjectMeta.Namespace, gw.ObjectMeta.Name)
+	values, err := lookupValues(ctx, r, gwc.Name, gwcb, gw.Namespace, gw.Name)
 	if err != nil {
 		logger.Error(err, "cannot lookup values", debugContext...)
 		return ctrl.Result{}, fmt.Errorf("cannot lookup values: %w", err)
@@ -253,7 +253,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			Type:               string(gatewayapi.ListenerConditionAccepted),
 			Status:             metav1.ConditionTrue,
 			Reason:             string(gatewayapi.ListenerReasonAccepted),
-			ObservedGeneration: gw.ObjectMeta.Generation})
+			ObservedGeneration: gw.Generation})
 	}
 
 	// Gateway was accepted as 'ours'
@@ -261,7 +261,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		Type:               string(gatewayapi.GatewayConditionAccepted),
 		Status:             metav1.ConditionTrue,
 		Reason:             string(gatewayapi.GatewayReasonAccepted),
-		ObservedGeneration: gw.ObjectMeta.Generation})
+		ObservedGeneration: gw.Generation})
 
 	// Consider Gateway as 'programmed' when all resources have
 	// been templated and applied
@@ -281,7 +281,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		Status:             progStatus,
 		Reason:             progReason,
 		Message:            progMsg,
-		ObservedGeneration: gw.ObjectMeta.Generation})
+		ObservedGeneration: gw.Generation})
 
 	// Set `Ready` condition based on child resource statuses, status update and programmed status
 	status := metav1.ConditionFalse
@@ -295,10 +295,10 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		status = metav1.ConditionTrue
 	}
 	meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
-		Type:               string(gatewayapi.GatewayConditionReady),
+		Type:               string(gatewayapi.GatewayConditionReady), //nolint:staticcheck // "Ready" is reserved for future use
 		Status:             status,
-		Reason:             string(gatewayapi.GatewayReasonReady),
-		ObservedGeneration: gw.ObjectMeta.Generation})
+		Reason:             string(gatewayapi.GatewayReasonReady), //nolint:staticcheck // "Ready" is reserved for future use
+		ObservedGeneration: gw.Generation})
 
 	if !equality.Semantic.DeepEqual(beforeStatusUpdate.Status, gw.Status) {
 		if err := r.Client().Status().Update(ctx, &gw); err != nil {
@@ -381,10 +381,10 @@ func filterHTTPRoutesForGateway(gw *gatewayapi.Gateway, rtList []*gatewayapi.HTT
 		for _, pRef := range rt.Spec.ParentRefs {
 			if (pRef.Group != nil && *pRef.Group != gatewayapi.Group(gatewayapi.GroupName)) ||
 				(pRef.Kind != nil && *pRef.Kind != gatewayapi.Kind("Gateway")) ||
-				(pRef.Namespace != nil && *pRef.Namespace != gatewayapi.Namespace(gw.ObjectMeta.Namespace)) ||
+				(pRef.Namespace != nil && *pRef.Namespace != gatewayapi.Namespace(gw.Namespace)) ||
 				// Unspecified namespace means use HTTPRoute namespace
-				(pRef.Namespace == nil && rt.ObjectMeta.Namespace != gw.ObjectMeta.Namespace) ||
-				(pRef.Name != gatewayapi.ObjectName(gw.ObjectMeta.Name)) {
+				(pRef.Namespace == nil && rt.Namespace != gw.Namespace) ||
+				(pRef.Name != gatewayapi.ObjectName(gw.Name)) {
 				// Skip as ParentRef does not refer to Gateway
 				continue
 			}

--- a/controllers/gatewayclass_controller.go
+++ b/controllers/gatewayclass_controller.go
@@ -40,7 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logger "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -90,7 +90,7 @@ func (r *GatewayClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *GatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := logger.FromContext(ctx)
+	logger := log.FromContext(ctx)
 	logger.Info("reconcile started", "gatewayClass", req.Name)
 
 	var valid = true
@@ -110,7 +110,7 @@ func (r *GatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	_, err = lookupGatewayClassBlueprint(ctx, r, gwc)
 	if err != nil {
 		valid = false
-		errWhyInvalid = fmt.Errorf("blueprint for GatewayClass '%s' not found", gwc.ObjectMeta.Name)
+		errWhyInvalid = fmt.Errorf("blueprint for GatewayClass '%s' not found", gwc.Name)
 		logger.Info("blueprint not found for GatewayClass", "gatewayClass", gwc.Name, "parametersRef", gwc.Spec.ParametersRef)
 	}
 
@@ -120,14 +120,14 @@ func (r *GatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			Type:               string(gatewayapi.GatewayClassConditionStatusAccepted),
 			Status:             "True",
 			Reason:             string(gatewayapi.GatewayClassReasonAccepted),
-			ObservedGeneration: gwc.ObjectMeta.Generation})
+			ObservedGeneration: gwc.Generation})
 	} else {
 		logger.V(1).Info("InvalidParameters", "gatewayClass", req.Name, "reason", errWhyInvalid)
 		meta.SetStatusCondition(&gwc.Status.Conditions, metav1.Condition{
 			Type:               string(gatewayapi.GatewayClassConditionStatusAccepted),
 			Status:             "False",
 			Reason:             string(gatewayapi.GatewayClassReasonInvalidParameters),
-			ObservedGeneration: gwc.ObjectMeta.Generation})
+			ObservedGeneration: gwc.Generation})
 	}
 
 	err = r.Client().Status().Update(ctx, gwc)

--- a/controllers/httproute_controller.go
+++ b/controllers/httproute_controller.go
@@ -110,7 +110,7 @@ func parentRefCmp(a, b gatewayapi.ParentReference) bool {
 // Lookup Gateway from parentRef
 func lookupParent(ctx context.Context, r ControllerClient, rt *gatewayapi.HTTPRoute, p gatewayapi.ParentReference) (*gatewayapi.Gateway, error) {
 	if p.Namespace == nil {
-		return lookupGateway(ctx, r, p.Name, rt.ObjectMeta.Namespace)
+		return lookupGateway(ctx, r, p.Name, rt.Namespace)
 	}
 	return lookupGateway(ctx, r, p.Name, string(*p.Namespace))
 }

--- a/controllers/templating.go
+++ b/controllers/templating.go
@@ -301,7 +301,7 @@ func template2maps(ctx context.Context, tmpl *template.Template, tmplValues *Tem
 		return nil, err
 	}
 
-	rawSlice := bytes.SplitN(renderBuffer.Bytes(), []byte("---"), -1)
+	rawSlice := bytes.Split(renderBuffer.Bytes(), []byte("---"))
 	resources := make([]map[string]any, 0, len(rawSlice))
 	for _, raw := range rawSlice {
 		r := map[string]any{}


### PR DESCRIPTION
**Description**

DCP-290: Fix linter issues

- Remove linter exclusion rules from `.golangci.yml`
- Fix import shadow: rename `logger` import alias to use package name `log`
- Simplify boolean assignment (QF1004)
- Remove redundant `.ObjectMeta` on embedded struct fields (QF1008)
- Use `bytes.Split` instead of `bytes.SplitN` (QF1007)
- Add inline `//nolint:staticcheck` for GatewayConditionReady (SA1019)