### PR TITLE
DCP-293: Fix security alerts

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -3,6 +3,9 @@ name: E2E-test
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/getting-started-usecase.yaml
+++ b/.github/workflows/getting-started-usecase.yaml
@@ -3,6 +3,9 @@ name: Getting-started-usecase
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -3,6 +3,9 @@ name: Test PR
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Description**

DCP-293: Fix CodeQL security alerts by adding explicit `permissions: contents: read` to all GitHub Actions workflows.