### PR TITLE
DCP-259: Remove `command` override from container specs

### DIFF
--- a/charts/bifrost-gateway-controller/templates/deployment.yaml
+++ b/charts/bifrost-gateway-controller/templates/deployment.yaml
@@ -34,8 +34,6 @@ spec:
         {{ if eq .Values.controller.logging.format "json" -}}
         - --zap-devel=false
         {{- end }}
-        command:
-        - /ko-app/bifrost-gateway-controller
         {{- if (contains "sha256:" .Values.controller.image.tag) }}
         image: "{{ .Values.controller.image.repository }}/{{ .Values.controller.image.name }}@{{ .Values.controller.image.tag }}"
           {{- else }}

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -61,9 +61,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       containers:
-      - command:
-        - /ko-app/bifrost-gateway-controller
-        args:
+      - args:
         - --leader-elect
         image: controller:latest
         name: manager

--- a/config/release/install.yaml
+++ b/config/release/install.yaml
@@ -783,8 +783,6 @@ spec:
       containers:
       - args:
         - --leader-elect
-        command:
-        - /ko-app/bifrost-gateway-controller
         image: ghcr.io/tv2/bifrost-gateway-controller:latest
         livenessProbe:
           httpGet:


### PR DESCRIPTION
**Description**

Remove the explicit `command` from the container spec in manager.yaml,
the Helm chart deployment template, and the release install manifest.

The `command` was overriding the image entrypoint to `/ko-app/bifrost-gateway-controller`, a legacy ko path. Current ko versions set the entrypoint to `/bifrost-gateway-controller` at build time, so the override is no longer needed.