### PR TITLE
DCP-281: Fix `renderTemplate` counting

### DIFF
--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -188,7 +188,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		templateValues.Resources = buildResourceValues(templates)
 
 		renderedNum, existsNum = renderTemplates(ctx, r, &gw, templates, &templateValues, isFinalAttempt)
-		logger.V(1).Info("rendered templates", "rendered", renderedNum, "exists", existsNum, "attempt", attempt)
+		logger.V(1).Info("rendered resources", "rendered", renderedNum, "exists", existsNum, "attempt", attempt)
 
 		if err = applyTemplates(ctx, r, &gw, templates); err != nil {
 			logger.Error(err, "unable to apply templates", debugContext...)
@@ -196,8 +196,8 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
-	requeue = (renderedNum != len(templates))
-	logger.V(1).Info("template loop completed", "renderedNum", renderedNum, "totalNum", len(templates), "requeue", requeue)
+	requeue = (renderedNum != existsNum)
+	logger.V(1).Info("template loop completed", "renderedNum", renderedNum, "existsNum", existsNum, "requeue", requeue)
 
 	beforeStatusUpdate := gw.DeepCopy()
 
@@ -268,13 +268,13 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	progStatus := metav1.ConditionFalse
 	progReason := "Pending"
 	progMsg := ""
-	if existsNum == len(templates) { // 'Programmed' relates to templates alone
+	missing := statusExistingTemplates(templates)
+	if len(missing) == 0 { // 'Programmed' when all templates rendered and all resources exist
 		progStatus = metav1.ConditionTrue
 		progReason = string(gatewayapi.GatewayReasonProgrammed)
 	} else {
-		missing := statusExistingTemplates(templates)
 		sort.Strings(missing)
-		progMsg = fmt.Sprintf("missing %v resources: %s", len(templates)-existsNum, strings.Join(missing, ","))
+		progMsg = fmt.Sprintf("missing %v resources: %s", len(missing), strings.Join(missing, ","))
 	}
 	meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
 		Type:               string(gatewayapi.GatewayConditionProgrammed),
@@ -308,8 +308,8 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if requeue {
-		if renderedNum != len(templates) {
-			logger.Info("requeuing, not all templates rendered", "renderedNum", renderedNum, "totalNum", len(templates))
+		if renderedNum != existsNum {
+			logger.Info("requeuing, not all resources available", "renderedNum", renderedNum, "existsNum", existsNum)
 		} else {
 			logger.Info("requeuing, status not yet available", "gateway", req.NamespacedName)
 		}

--- a/controllers/httproute_controller.go
+++ b/controllers/httproute_controller.go
@@ -256,16 +256,16 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			templateValues.Resources = buildResourceValues(templates)
 
 			renderedNum, existsNum = renderTemplates(ctx, r, &rt, templates, &templateValues, isFinalAttempt)
-			logger.V(1).Info("rendered templates", "rendered", renderedNum, "exists", existsNum, "attempt", attempt)
+			logger.V(1).Info("rendered resources", "rendered", renderedNum, "exists", existsNum, "attempt", attempt)
 
 			if err := applyTemplates(ctx, r, &rt, templates); err != nil {
 				logger.Error(err, "unable to apply templates", parentDebugCtx...)
 				return ctrl.Result{}, fmt.Errorf("unable to apply templates: %w", err)
 			}
 		}
-		// If we haven't already decided to requeue, then requeue if not all templates could render (possibly a missing dependency)
-		requeue = requeue || (renderedNum != len(templates))
-		logger.V(1).Info("template loop completed", "parentGateway", parent.Name, "renderedNum", renderedNum, "totalNum", len(templates), "requeue", requeue)
+		// If we haven't already decided to requeue, then requeue if not all resources could be found
+		requeue = requeue || (renderedNum != existsNum)
+		logger.V(1).Info("template loop completed", "parentGateway", parent.Name, "renderedNum", renderedNum, "existsNum", existsNum, "requeue", requeue)
 
 		// FIXME errors in templating and status of sub-resources in general should set status conditions
 

--- a/controllers/templating.go
+++ b/controllers/templating.go
@@ -179,7 +179,7 @@ func renderTemplates(ctx context.Context, r ControllerDynClient, parent metav1.O
 			}
 			logger.V(1).Info("template rendered", "templateName", tmpl.TemplateName, "resources", len(tmpl.Resources))
 		}
-		rendered++
+		rendered += len(tmpl.Resources)
 		for resIdx := range tmpl.Resources {
 			res := &tmpl.Resources[resIdx]
 			if res.Current == nil {
@@ -199,8 +199,8 @@ func renderTemplates(ctx context.Context, r ControllerDynClient, parent metav1.O
 			} else {
 				logger.V(1).Info("current resource already cached", "templateName", tmpl.TemplateName, "resourceName", res.Rendered.GetName())
 			}
+			exists++
 		}
-		exists++
 	}
 	return rendered, exists
 }

--- a/controllers/templating_test.go
+++ b/controllers/templating_test.go
@@ -153,7 +153,7 @@ var _ = Describe("renderTemplates", func() {
 		}
 		rendered, exists := renderTemplates(ctx, r, newTestParentGateway(), templates, &TemplateValues{}, false)
 		Expect(rendered).To(Equal(1))
-		Expect(exists).To(Equal(1))
+		Expect(exists).To(Equal(0)) // Resource not yet in cluster (fake client has no objects)
 	})
 
 	It("Should skip already rendered templates", func() {
@@ -197,7 +197,7 @@ var _ = Describe("renderTemplates", func() {
 			{TemplateName: "bad", Template: badTmpl, StringTemplate: "val: {{ .Values.missing }}"},
 		}
 		rendered, exists := renderTemplates(ctx, r, newTestParentGateway(), templates, &TemplateValues{}, false)
-		Expect(rendered).To(Equal(1)) // TODO: seems weird that rendered and exists always equal the same.
+		Expect(rendered).To(Equal(1))
 		Expect(exists).To(Equal(1))
 	})
 })


### PR DESCRIPTION
**Description**

DCP-281: Fix renderTemplates() counters to count individual resources

renderTemplates() previously counted templates rather than individual resources. A template producing 3 resources counted the same as one producing 1.

- `rendered` now sums len(tmpl.Resources) across parsed templates
- `exists` now counts resources actually found in the cluster
- Requeue logic, `Programmed` condition, and log messages updated to match