### PR TITLE
DCP-266: Namespace specification via helm

### DIFF
--- a/charts/bifrost-gateway-controller/templates/deployment.yaml
+++ b/charts/bifrost-gateway-controller/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
       containers:
       - args:
         - --leader-elect
+        - --controller-namespace={{ .Release.Namespace }}
         - --zap-log-level={{ .Values.controller.logging.level }}
         {{ if eq .Values.controller.logging.format "json" -}}
         - --zap-devel=false


### PR DESCRIPTION
**Description**

DCP-266: pass `--controller-namespace` from helm release namespace

