### PR TITLE
chore: rename team in CODEOWNERS to development-platform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 
 # Each line is a file pattern followed by one or more owners.
 
-*       @tv2/developer-cloud-platform
+*       @tv2/development-platform


### PR DESCRIPTION
Rename `@tv2/developer-cloud-platform` → `@tv2/development-platform` to reflect the new team name.