### PR TITLE
ci: test that crds are updated on release

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -57,6 +57,8 @@ jobs:
         run: |
           rm -rf config/release
           devbox run -- make manifest-build
+          git status --porcelain
+          if [[ -z `git status --porcelain` ]]; then echo "No repo changes"; else echo "Repo have unexpected changes"; exit 1; fi
 
       - name: Build and push container image
         id: ko

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -57,8 +57,9 @@ jobs:
         run: |
           rm -rf config/release
           devbox run -- make manifest-build
-          git status --porcelain
-          if [[ -z `git status --porcelain` ]]; then echo "No repo changes"; else echo "Repo have unexpected changes"; exit 1; fi
+          status=$(git status --porcelain)
+          echo "$status"
+          if [[ -z "$status" ]]; then echo "No repo changes"; else echo "Repo have unexpected changes"; exit 1; fi
 
       - name: Build and push container image
         id: ko


### PR DESCRIPTION
We already ran the 'generate manifests' step, but forgot to check for diffs.