### PR TITLE
chore: remove wildcard (*) CODEOWNERS entry to stop auto-assigning Development Platform on every PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-
-# Each line is a file pattern followed by one or more owners.
-
-*       @tv2/development-platform


### PR DESCRIPTION
Removes only the `*` catch-all **pattern** from CODEOWNERS so the Development Platform team is no longer automatically requested as a reviewer on **every** PR. Path-specific ownership rules are left intact.

Part of an org-wide cleanup across repositories with the `Team = Development Platform` custom property.