### PR TITLE
fix(logging: log template render deferral as error instead of debug

### DIFF
--- a/controllers/templating.go
+++ b/controllers/templating.go
@@ -173,7 +173,7 @@ func renderTemplates(ctx context.Context, r ControllerDynClient, parent metav1.O
 					logger.V(2).Info("template render failure details", "templateName", tmpl.TemplateName, "template", tmpl.StringTemplate, "values", values)
 					metricTemplateErrs.Inc()
 				} else {
-					logger.V(1).Info("template render deferred (missing dependency)", "templateName", tmpl.TemplateName, "error", err)
+					logger.Error(err, "template render deferred (missing dependency)", "templateName", tmpl.TemplateName)
 				}
 				continue
 			}


### PR DESCRIPTION
Changes the "template render deferred (missing dependency)" log line from `logger.V(1).Info` (debug) to `logger.Error`, so deferred template renders are surfaced at error level.